### PR TITLE
Refactor insertion to use callbacks

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -9,6 +9,12 @@
 ///
 /// [`RleTree`]: crate::RleTree
 pub trait Cursor: Sized {
+    /// Marker for whether the cursor does nothing
+    ///
+    /// Practically speaking, this only really exists so that we can optimize uses of [`NoCursor`],
+    /// but you're welcome to set this if you'd like :)
+    const IS_NOP: bool = false;
+
     /// Creates a new `Cursor` with an empty path
     fn new_empty() -> Self;
 
@@ -113,6 +119,7 @@ pub struct NoCursor;
 
 #[rustfmt::skip]
 impl Cursor for NoCursor {
+    const IS_NOP: bool = true;
     fn new_empty() -> Self { NoCursor }
     fn prepend_to_path(&mut self, _: PathComponent) {}
     type PathIter = std::iter::Empty<PathComponent>;

--- a/src/tree/fix.rs
+++ b/src/tree/fix.rs
@@ -1,0 +1,757 @@
+//! Common tools for handling tree restructuring and post-operation updates
+//!
+//! Broadly speaking, this module is only intended to cover the _most_ generic pieces; modules like
+//! `insert` are intended to handle their specific algorithms.
+//!
+//! A brief summary of items here:
+//!
+//! * [`MapState`] - a helper trait for creating and using state mapping callbacks
+//! * [`TraverseUpdate`] - used with the [`apply_to_ref`] method to track [`SliceHandle`] positions
+//!   without other algorithms needing to be aware of them
+//! * [`OpUpdateState`] - provides general "shift positions around after we've done an operation"
+//!   handling, for use in a variety of contexts.
+//! * [`ShiftKeys`] - provides a some tools to shift a range of positions in a node, with the
+//!   related [`shift_keys_auto`], [`shift_keys_increase`], and [`shift_keys_decrease`] functions.
+//!
+//! [`apply_to_ref`]: TraverseUpdate::apply_to_ref
+
+use crate::param::RleTreeConfig;
+use crate::{Cursor, Index, PathComponent, Slice};
+use std::ops::{ControlFlow, Range};
+
+use super::node::{borrow, ty, ChildOrKey, NodeHandle, NodePtr, SliceHandle};
+
+#[cfg(test)]
+use crate::MaybeDebug;
+#[cfg(test)]
+use std::fmt::{self, Debug, Formatter};
+
+//////////////
+// MapState //
+//////////////
+
+/// Helper trait to allow state mapping callback sets to be easily constructed and used
+///
+/// This trait _may_ have some issues around under-inlining due to the implementations' use of
+/// `dyn` functions. On the other hand, under-inlining may actually provide a net benefit because
+/// of reduced code output. In future, we can try benchmarking this version vs. a macro-based
+/// replacement.
+///
+/// Implementors (and `Map` types):
+///
+///  * [`OpUpdateState`] ([`MapOpUpdateState`])
+pub(super) trait MapState {
+    /// Generic type for functions, or sets of functions, that can be used to map values of `Self`
+    ///
+    /// Typically, `Map`s are either `&'f mut dyn FnMut(Self) -> Self` or a struct containing
+    /// multiple such functions. We use this to prevent certain properties of `Self` from being
+    /// changed -- whether that's enum variants or a subset of struct fields.
+    type Map<'f>
+    where
+        Self: 'f;
+
+    /// Produces the identity mapping -- i.e., the one that when used with `map` will leave the
+    /// input unchanged
+    fn identity<'f>() -> Self::Map<'f>
+    where
+        Self: 'f;
+    /// Calls the provided function(s) `self` (or pieces of it), returning the new value
+    fn map<'f>(self, f: &mut Self::Map<'f>) -> Self
+    where
+        Self: 'f;
+}
+
+/// Struct containing `dyn` functions that map [`OpUpdateState`]s (See: [`MapState`])
+///
+/// Both functions are provided the [`NodeHandle`] taken from `child_or_key` to allow functions
+/// using extra context.
+pub(super) struct MapOpUpdateState<'f, 't, C, I, S, P: RleTreeConfig<I, S, M>, const M: usize> {
+    pub(super) cursor:
+        Option<&'f mut dyn FnMut(&NodeHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>, C) -> C>,
+    pub(super) sizes: Option<
+        &'f mut dyn FnMut(
+            &mut NodeHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>,
+            ChildOrKey<u8, u8>,
+            OpUpdateStateSizes<I>,
+        ) -> OpUpdateStateSizes<I>,
+    >,
+}
+
+/// Struct representing the subset of fields in an [`OpUpdateState`] that refer to sizes and
+/// positions
+pub(super) struct OpUpdateStateSizes<I> {
+    pub(super) override_pos: Option<I>,
+    pub(super) old_size: I,
+    pub(super) new_size: I,
+}
+
+#[rustfmt::skip]
+impl<'t, C, I, S, P, const M: usize> MapState for OpUpdateState<'t, C, I, S, P, M>
+where
+    P: RleTreeConfig<I, S, M>,
+{
+    type Map<'f> = MapOpUpdateState<'f, 't, C, I, S, P, M>
+        where Self: 'f;
+
+    fn identity<'f>() -> Self::Map<'f>
+        where Self: 'f,
+    {
+        MapOpUpdateState {
+            cursor: None,
+            sizes: None,
+        }
+    }
+
+    fn map<'f>(mut self, f: &mut Self::Map<'f>) -> Self
+        where Self: 'f,
+    {
+        let (node, child_or_key) = match &mut self.child_or_key {
+            ChildOrKey::Key((ki, n)) => (n, ChildOrKey::Key(*ki)),
+            ChildOrKey::Child((ci, n)) => (n.untyped_mut(), ChildOrKey::Child(*ci)),
+        };
+
+        if let Some(map_cursor) = f.cursor.as_mut() {
+            self.partial_cursor = map_cursor(node, self.partial_cursor);
+        }
+
+        if let Some(map_sizes) = f.sizes.as_mut() {
+            let new_sizes = map_sizes(node, child_or_key, OpUpdateStateSizes {
+                override_pos: self.override_pos,
+                old_size: self.old_size,
+                new_size: self.new_size,
+            });
+            self.override_pos = new_sizes.override_pos;
+            self.old_size = new_sizes.old_size;
+            self.new_size = new_sizes.new_size;
+        }
+
+        self
+    }
+}
+
+////////////////////
+// TraverseUpdate //
+////////////////////
+
+/// Update type passed to tree restructuring callbacks
+///
+/// This type exists so that things like slice references from `insert_ref` can be appropriately
+/// updated by algorithms that don't need to be aware of their existence.
+///
+/// Note: The slice references stored in the tree's [`SliceRefStore`] are already updated by the
+/// methods on the [`NodeHandle`]s and [`SliceHandle`]s; they do not need to be accounted for here.
+///
+/// [`SliceRefStore`]: super::slice_ref::SliceRefStore
+pub(super) enum TraverseUpdate<I, S, P: RleTreeConfig<I, S, M>, const M: usize> {
+    /// Records that an insertion occured.
+    ///
+    /// There are some operations that generate multiple insertion operations. It's typically the
+    /// responsibility of the provided callback to filter them out appropriately.
+    Insertion {
+        ptr: NodePtr<I, S, P, M>,
+        height: u8,
+        idx: u8,
+    },
+    /// Records that a range of slices have moved -- either within or between nodes
+    ///
+    /// It is *guaranteed* that `new_ptr` is a valid node in the tree, that `old_range` and
+    /// `new_range` have the same length, and that the slices `(*new_ptr)[new_range]` are all
+    /// initialized. It is allowed for `old_ptr` to have been deallocated by the time the callback
+    /// receives the `Move` update.
+    Move {
+        old_ptr: NodePtr<I, S, P, M>,
+        old_range: Range<u8>,
+        new_ptr: NodePtr<I, S, P, M>,
+        new_height: u8,
+        new_range: Range<u8>,
+    },
+    /// Marks the slice as being temporarily removed from the tree
+    Remove {
+        ptr: NodePtr<I, S, P, M>,
+        height: u8,
+        idx: u8,
+    },
+    /// Returns a previously removed (via `Remove`) slice to a new position in the tree
+    ///
+    /// It is *guaranteed* by the caller of a callback using `TraverseUpdate` that `PutBack` will
+    /// be provided exactly once after each `Remove`, without more than one `Remove` before the
+    /// appropriate `PutBack`.
+    ///
+    /// **Note**: this variant is _also_ used to signal the initial creation of the `SliceRef`
+    PutBack {
+        ptr: NodePtr<I, S, P, M>,
+        height: u8,
+        idx: u8,
+    },
+}
+
+#[cfg(test)]
+impl<I, S, P, const M: usize> Debug for TraverseUpdate<I, S, P, M>
+where
+    P: RleTreeConfig<I, S, M>,
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Insertion { ptr, height, idx } => f
+                .debug_struct("Insertion")
+                .field("ptr", ptr)
+                .field("height", height)
+                .field("idx", idx)
+                .finish(),
+            #[rustfmt::skip]
+            Self::Move { old_ptr, old_range, new_ptr, new_height, new_range } => f
+                .debug_struct("Move")
+                .field("old_ptr", old_ptr)
+                .field("old_range", old_range)
+                .field("new_ptr", new_ptr)
+                .field("new_height", new_height)
+                .field("new_range", new_range)
+                .finish(),
+            Self::Remove { ptr, height, idx } => f
+                .debug_struct("Remove")
+                .field("ptr", ptr)
+                .field("height", height)
+                .field("idx", idx)
+                .finish(),
+            Self::PutBack { ptr, height, idx } => f
+                .debug_struct("PutBack")
+                .field("ptr", ptr)
+                .field("height", height)
+                .field("idx", idx)
+                .finish(),
+        }
+    }
+}
+
+impl<I, S, P, const M: usize> TraverseUpdate<I, S, P, M>
+where
+    P: RleTreeConfig<I, S, M>,
+{
+    /// Creates a new `TraverseUpdate::Insertion` referring to the given slice
+    pub(super) fn insert<Ty: ty::TypeHint, B>(handle: &SliceHandle<Ty, B, I, S, P, M>) -> Self {
+        TraverseUpdate::Insertion {
+            ptr: handle.node.ptr(),
+            height: handle.node.height(),
+            idx: handle.idx,
+        }
+    }
+
+    /// Creates a new `TraverseUpdate::PutBack` referring to the given slice
+    pub(super) fn put_back<Ty: ty::TypeHint, B>(handle: &SliceHandle<Ty, B, I, S, P, M>) -> Self {
+        TraverseUpdate::PutBack {
+            ptr: handle.node.ptr(),
+            height: handle.node.height(),
+            idx: handle.idx,
+        }
+    }
+
+    /// Creates an iterator of `TraverseUpdate`s corresponding to splitting the given node at the
+    /// index
+    #[rustfmt::skip]
+    pub(super) fn split<Ty: ty::TypeHint, B>(
+        lhs: &NodeHandle<Ty, B, I, S, P, M>,
+        idx: u8,
+        rhs: &NodeHandle<Ty, borrow::UniqueOwned, I, S, P, M>,
+    ) -> impl IntoIterator<Item = TraverseUpdate<I, S, P, M>> {
+        [
+            Self::Move {
+                old_ptr: lhs.ptr(), old_range: idx + 1..idx + 1 + rhs.leaf().len(),
+                new_ptr: rhs.ptr(), new_range: 0..rhs.leaf().len(), new_height: rhs.height(),
+            },
+            Self::Remove { ptr: lhs.ptr(), height: lhs.height(), idx: lhs.leaf().len() },
+        ]
+    }
+
+    /// Consumes a `TraverseUpdate` and does nothing
+    ///
+    /// It's generally preferred to use this function instead of providing your own, for two
+    /// reasons:
+    ///
+    /// 1. This method is more explicit;
+    /// 2. The validity of the arguments are checked in debug mode; and
+    /// 3. While debugging, we can easily log the arguments passed to this function, whereas
+    ///    tracking down all instances of `|_| {}` may be more tedious
+    pub(super) fn do_nothing(self) {
+        #[cfg(any(test, debug_assertions))]
+        self.assert_valid();
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    fn assert_valid(&self) {
+        match self {
+            // Nothing we can validate, because it would make assumptions about the current state
+            // of the node, which we generally aren't allowed to do.
+            TraverseUpdate::Insertion { ptr: _, height: _, idx: _ }
+            | TraverseUpdate::Remove { ptr: _, height: _, idx: _ }
+            | TraverseUpdate::PutBack { ptr: _, height: _, idx: _ } => (),
+
+            #[rustfmt::skip]
+            TraverseUpdate::Move {
+                old_ptr: _, old_range,
+                new_ptr: _, new_range, new_height: _,
+            } => {
+                assert!(old_range.start <= old_range.end);
+                assert!(new_range.start <= new_range.end);
+                assert_eq!(old_range.len(), new_range.len());
+            }
+        }
+    }
+
+    /// Returns a closure that applies `TraverseUpdate`s to the given reference
+    ///
+    /// Roughly speaking, it starts from the first [`TraverseUpdate::Insertion`] and tracks the
+    /// position afterwards.
+    ///
+    /// ## Panics
+    ///
+    /// Calling `apply_to_ref` will never _directly_ panic. The closure it returns can, however,
+    /// and it's worth documenting those conditions. They are:
+    ///
+    /// * If the closure is called with `TraverseUpdate::Insertion` more than once (or: at all, if
+    ///   `slice_ref` was initially `Some(_)`)
+    /// * If the closure is called with `TraverseUpdate::Remove` in a row, without a
+    ///   `TraverseUpdate::PutBack` between (disregarding `Insertion`s or `Move`s).
+    ///
+    /// ## Safety
+    ///
+    /// The caller guarantees that all values provided to the callback accurately reflect changes
+    /// occuring in the tree. This can be assumed for most functions.
+    pub(super) unsafe fn apply_to_ref(
+        slice_ref: &mut Option<SliceHandle<ty::Unknown, borrow::SliceRef, I, S, P, M>>,
+    ) -> impl '_ + FnMut(TraverseUpdate<I, S, P, M>) {
+        // The implementation of the update step, written as a pure function with mutable inputs
+        //
+        // This is extracted so that it's easy to inject logging into the closure we return.
+        fn do_update<I, S, P: RleTreeConfig<I, S, M>, const M: usize>(
+            update: TraverseUpdate<I, S, P, M>,
+            already_present: &mut bool,
+            slice_ref: &mut Option<SliceHandle<ty::Unknown, borrow::SliceRef, I, S, P, M>>,
+        ) {
+            match (update, &slice_ref) {
+                (TraverseUpdate::Insertion { .. }, Some(_)) => unreachable!(),
+                (TraverseUpdate::Insertion { .. }, None) if *already_present => unreachable!(),
+                (TraverseUpdate::Insertion { ptr, height, idx }, None) => {
+                    *slice_ref = Some(unsafe { SliceHandle::from_raw_parts(ptr, height, idx) });
+                    *already_present = true;
+                }
+
+                // `Move` with nothing stored does nothing
+                (TraverseUpdate::Move { .. }, None) => (),
+                // `Move` that doesn't overlap the contents does nothing
+                (TraverseUpdate::Move { old_ptr, old_range, .. }, Some(r))
+                    if old_ptr != r.node.ptr() || !old_range.contains(&r.idx) => {}
+                // `Move` does the expected thing when it affects the stored handle
+                (
+                    TraverseUpdate::Move { old_range, new_ptr, new_height, new_range, .. },
+                    Some(r),
+                ) => {
+                    debug_assert_eq!(old_range.len(), new_range.len());
+
+                    let new_idx = (r.idx - old_range.start) + new_range.start;
+                    *slice_ref =
+                        Some(unsafe { SliceHandle::from_raw_parts(new_ptr, new_height, new_idx) });
+                }
+
+                // We shouldn't get `Remove`s when there's nothing there right now
+                (TraverseUpdate::Remove { .. }, None) => {
+                    if *already_present {
+                        unreachable!()
+                    }
+                }
+                // `Remove` doesn't do anything if it doesn't affect the stored handle
+                (TraverseUpdate::Remove { ptr, idx, .. }, Some(r))
+                    if ptr != r.node.ptr() || idx != r.idx => {}
+                // `Remove` affecting the stored handle... removes it.
+                (TraverseUpdate::Remove { height, .. }, Some(h)) => {
+                    debug_assert_eq!(h.node.height(), height);
+                    *slice_ref = None;
+                }
+
+                (TraverseUpdate::PutBack { .. }, Some(_)) => (),
+                (TraverseUpdate::PutBack { ptr, height, idx }, None) => {
+                    if *already_present {
+                        *slice_ref = Some(unsafe { SliceHandle::from_raw_parts(ptr, height, idx) });
+                    }
+                }
+            }
+        }
+
+        let mut already_present = slice_ref.is_some();
+        move |update: TraverseUpdate<I, S, P, M>| {
+            // space reserved for adding debugging :)
+            do_update(update, &mut already_present, slice_ref);
+        }
+    }
+
+    /// Produces a closure that calls `f` for all `TraverseUpdate`s except `Insertion`s
+    pub(super) fn skip_insertions<'f>(
+        mut f: impl 'f + FnMut(TraverseUpdate<I, S, P, M>),
+    ) -> impl 'f + FnMut(TraverseUpdate<I, S, P, M>) {
+        move |upd: TraverseUpdate<I, S, P, M>| match upd {
+            TraverseUpdate::Insertion { .. } => {}
+            u => f(u),
+        }
+    }
+}
+
+///////////////////
+// OpUpdateState //
+///////////////////
+
+/// State recording how to propagate an update to the size of the tree as we traverse upwards
+pub(super) struct OpUpdateState<'t, C, I, S, P: RleTreeConfig<I, S, M>, const M: usize> {
+    /// The key or child containing the change as we're traversing upwards, alongside the typed
+    /// node containing it
+    ///
+    /// For keys that are positioned after this child or key (i.e. at a greater index), their
+    /// positions within the node can be updated with:
+    ///
+    /// ```text
+    /// |- ... -------------- key --------------|   (original position of a key after `child_or_key`)
+    /// |- ... --- pos ---|                         (node-relative `child_or_key` position)
+    ///                   |- key.sub_left(pos) -|
+    ///                   |---- new_size ----|
+    ///                                      |- key.sub_left(pos) -|  (same size as above, shifted)
+    ///                   |- key.sub_left(pos).add_left(new_size) -|
+    /// |- ... - key.sub_left(pos).add_left(new_size).add_left(pos) -|  (new key position)
+    /// ```
+    ///
+    /// The final result, `key.sub_left(pos).add_left(new_size).add_left(pos)` can largely be
+    /// tracked by a running total of the distance from each key back to the changed child/key,
+    /// adding the distance between keys each time. So the value is then
+    /// `key.sub_left(pos).add_left(sum)`.
+    ///
+    /// This careful dance is only there because we have to make sure that we uphold the guarantees
+    /// we provide for directional arithmetic -- we can't just `add_left(size)` because that's not
+    /// where the slice is.
+    ///
+    /// If the usage around this is written in *just* the right way, the compiler should realize
+    /// what's going on and optimize it to (approximately) `key += size` or `key -= size`,
+    /// depending on the operation.
+    pub(super) child_or_key: ChildOrKey<
+        // Child: must be internal
+        (u8, NodeHandle<ty::Internal, borrow::Mut<'t>, I, S, P, M>),
+        // Key: unknown type
+        (u8, NodeHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>),
+    >,
+
+    /// Optional override in case the start position of the size change is not equal to the start
+    /// position given by `child_or_key`
+    pub(super) override_pos: Option<I>,
+
+    /// The old size of the child or key containing the change
+    pub(super) old_size: I,
+    /// The new size of the child or key containing the change. This is provided separately so that
+    /// it can be updated *after* the original size has been recorded
+    pub(super) new_size: I,
+
+    /// Cursor representing the path to the deepest node containing the change
+    ///
+    /// This cursor is often empty.
+    ///
+    /// ---
+    ///
+    /// In theory, it's entirely possible to use `inserted_slice` to build a cursor after the fact
+    /// and get the exact path to the insertion. In practice, this involves doing a second upwards
+    /// tree traversal, so we opt for an imperfect "good enough" solution that minimizes additional
+    /// costs.
+    pub(super) partial_cursor: C,
+}
+
+#[cfg(test)]
+impl<'t, C, I, S, P, const M: usize> Debug for OpUpdateState<'t, C, I, S, P, M>
+where
+    P: RleTreeConfig<I, S, M>,
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let (idx_name, idx, node) = match &self.child_or_key {
+            ChildOrKey::Key((k_idx, node)) => ("key_idx", k_idx, node),
+            ChildOrKey::Child((c_idx, node)) => ("child_idx", c_idx, node.untyped_ref()),
+        };
+
+        f.debug_struct("OpUpdateState")
+            .field("node", node)
+            .field(idx_name, idx)
+            .field("override_pos", self.override_pos.fallible_debug())
+            .field("old_size", self.old_size.fallible_debug())
+            .field("new_size", self.new_size.fallible_debug())
+            .finish()
+    }
+}
+
+impl<'t, C, I, S, P, const M: usize> OpUpdateState<'t, C, I, S, P, M>
+where
+    C: Cursor,
+    I: Index,
+    S: Slice<I>,
+    P: RleTreeConfig<I, S, M>,
+{
+    /// Runs the post-operation tree changes to completion, using the callbacks to modify the
+    /// behavior as necessary
+    ///
+    /// Each call to `early_exit` is made _after_ `map_state` for a given node, and before calling
+    /// [`do_upward_step`](Self::do_upward_step).
+    pub(super) fn finish<'m>(
+        mut self,
+        mut map_state: <Self as MapState>::Map<'m>,
+        mut early_exit: Option<&mut dyn FnMut(&Self) -> ControlFlow<()>>,
+    ) -> C
+    where
+        Self: 'm,
+    {
+        loop {
+            self = self.map(&mut map_state);
+
+            if let Some(ControlFlow::Break(())) = early_exit.as_mut().map(|f| f(&self)) {
+                return self.partial_cursor;
+            }
+
+            match self.do_upward_step() {
+                Ok(final_cursor) => return final_cursor,
+                Err(new_state) => self = new_state,
+            }
+        }
+    }
+
+    /// Performs a single upward step of the `OpUpdateState`, moving its focused node towards the
+    /// root
+    ///
+    /// Typically this method will not be used directly, and instead
+    pub(super) fn do_upward_step(mut self) -> Result<C, Self> {
+        // The first part of the traversal step starts with repositioning all of the keys after
+        // `self.child_or_key`.
+
+        let (mut node, first_key_after, maybe_child_idx, pos) = match self.child_or_key {
+            ChildOrKey::Key((k_idx, node)) => {
+                let pos = self
+                    .override_pos
+                    // SAFETY: The documentation for `PostInsertTraversalState` guarantees that
+                    // `k_idx` is within bounds.
+                    .unwrap_or_else(|| unsafe { node.leaf().key_pos(k_idx) });
+
+                (node, k_idx + 1, None, pos)
+            }
+            ChildOrKey::Child((c_idx, node)) => {
+                let pos = self.override_pos.unwrap_or_else(|| {
+                    let next_key_pos = node
+                        .leaf()
+                        .try_key_pos(c_idx)
+                        .unwrap_or_else(|| node.leaf().subtree_size());
+                    next_key_pos.sub_left(self.old_size)
+                });
+
+                (node.erase_type(), c_idx, Some(c_idx), pos)
+            }
+        };
+
+        let old_size = node.leaf().subtree_size();
+
+        // SAFETY: `shift_keys` only requires that `from` is less than or equal to
+        // `node.leaf().len()`. This can be verified by looking at the code above; `from` is either
+        // set to `k_idx + 1` or to `c_idx`, both of which exactly meet the required bound.
+        unsafe {
+            shift_keys_increase(&mut node, ShiftKeys {
+                from: first_key_after,
+                pos,
+                old_size: self.old_size,
+                new_size: self.new_size,
+            });
+        }
+
+        let new_size = node.leaf().subtree_size();
+
+        // Update the cursor
+        //
+        // Technically speaking, this relies on this node having `child_or_key =
+        // ChildOrKey::Child(_)` as long as the cursor is non-empty, but that should always be
+        // true.
+        if let Some(child_idx) = maybe_child_idx {
+            self.partial_cursor.prepend_to_path(PathComponent { child_idx });
+        }
+
+        // Update `self` to the parent, if there is one. Otherwise, this is the root node so we
+        // should return `Err` with the cursor and reference to the insertion.
+        match node.into_parent().ok() {
+            None => Ok(self.partial_cursor),
+            Some((parent_handle, c_idx)) => Err(OpUpdateState {
+                child_or_key: ChildOrKey::Child((c_idx, parent_handle)),
+                override_pos: None,
+                old_size,
+                new_size,
+                partial_cursor: self.partial_cursor,
+            }),
+        }
+    }
+}
+
+///////////////////////
+// `ShiftKeys` et al //
+///////////////////////
+
+/// (*Internal*) Helper struct for [`shift_keys`], so that the parameters are named and we can
+/// provide a bit more documentation
+pub(super) struct ShiftKeys<I> {
+    /// First key index to update. May be equal to node length
+    pub from: u8,
+    /// The position of the earlier change in the node
+    ///
+    /// We're being intentionally vague here because this can correspond to multiple different
+    /// things. `PostInsertTraversalState`, for example, uses this as the index of an updated
+    /// child or key. But for cases where we've inserted multiple things (e.g., where
+    /// [`insert_rhs`] is provided a second value), this might only correspond to the index of the
+    /// first item, with `old_size` and `new_size` referring to the total size of the pieces.
+    ///
+    /// [`insert_rhs`]: crate::RleTree::insert_rhs
+    pub pos: I,
+    /// The old size of the object at `pos`
+    pub old_size: I,
+    /// The new size of the object at `pos`
+    ///
+    /// If [`shift_keys`] is given `IS_INCREASE = true`, then `new_size` will be expected to be
+    /// greater than `old_size`. Otherwise, `new_size` *should* be less than `old_size`. We can't
+    /// *guarantee* that this will be true, because of the limitations exposed by user-defined
+    /// implementations of `Ord` for `I`, but in general these conditions should hold.
+    pub new_size: I,
+}
+
+/// (*Internal*) Updates the positions of all keys in a node, calling either
+/// [`shift_keys_increase`] or [`shift_keys_decrease`] depending on whether the size has increased
+/// or decreased
+///
+/// ## Safety
+///
+/// The value of `opts.from` must be less than or equal to `node.leaf().len()`.
+pub(super) unsafe fn shift_keys_auto<'t, Ty, I, S, P, const M: usize>(
+    node: &mut NodeHandle<Ty, borrow::Mut<'t>, I, S, P, M>,
+    opts: ShiftKeys<I>,
+) where
+    Ty: ty::TypeHint,
+    I: Index,
+    P: RleTreeConfig<I, S, M>,
+{
+    // SAFETY: guaranteed by caller
+    unsafe {
+        if opts.new_size > opts.old_size {
+            shift_keys_increase(node, opts)
+        } else {
+            shift_keys_decrease(node, opts)
+        }
+    }
+}
+
+/// (*Internal*) Updates the positions of all keys in a node, expecting them to increase
+///
+/// ## Safety
+///
+/// The value of `opts.from` must be less than or equal to `node.leaf().len()`.
+pub(super) unsafe fn shift_keys_increase<'t, Ty, I, S, P, const M: usize>(
+    node: &mut NodeHandle<Ty, borrow::Mut<'t>, I, S, P, M>,
+    opts: ShiftKeys<I>,
+) where
+    Ty: ty::TypeHint,
+    I: Index,
+    P: RleTreeConfig<I, S, M>,
+{
+    // SAFETY: guaranteed by caller
+    unsafe { shift_keys::<Ty, I, S, P, M, true>(node, opts) }
+}
+
+/// (*Internal*) Updates the positions of all keys in a node, expecting them to decrease
+///
+/// ## Safety
+///
+/// The value of `opts.from` must be less than or equal to `node.leaf().len()`.
+pub(super) unsafe fn shift_keys_decrease<'t, Ty, I, S, P, const M: usize>(
+    node: &mut NodeHandle<Ty, borrow::Mut<'t>, I, S, P, M>,
+    opts: ShiftKeys<I>,
+) where
+    Ty: ty::TypeHint,
+    I: Index,
+    P: RleTreeConfig<I, S, M>,
+{
+    // SAFETY: guaranteed by caller
+    unsafe { shift_keys::<Ty, I, S, P, M, false>(node, opts) }
+}
+
+/// (*Internal*) Updates the positions of all keys in a node
+///
+/// Typically this function is called via [`shift_keys_increase`] or [`shift_keys_decrease`] to
+/// avoid manually specifying the generic args.
+///
+/// ## Safety
+///
+/// The value of `opts.from` must be less than or equal to `node.leaf().len()`.
+pub(super) unsafe fn shift_keys<'t, Ty, I, S, P, const M: usize, const IS_INCREASE: bool>(
+    node: &mut NodeHandle<Ty, borrow::Mut<'t>, I, S, P, M>,
+    opts: ShiftKeys<I>,
+) where
+    Ty: ty::TypeHint,
+    I: Index,
+    P: RleTreeConfig<I, S, M>,
+{
+    // SAFETY: guaranteed by caller
+    unsafe { weak_assert!(opts.from <= node.leaf().len()) };
+
+    let ShiftKeys { from, pos, old_size, new_size } = opts;
+
+    // Because some of the jumping through hoops can get a little confusing in this function, we've
+    // illustrated how all of the positions are laid out below.
+    //
+    // First, define `old_end = pos.add_right(old_size)` and `new_end = pos.add_right(new_size)`.
+    // Visually, this is:
+    //
+    //   |------------- old_end ------------|
+    //   |- ... ---- pos ----|-- old_size --|
+    //
+    //   |--------------- new_end --------------|
+    //   |- ... ---- pos ----|---- new_size ----|
+    //
+    // These abbreviations help make the illustration below a little more compact. In either case
+    // of `IS_INCREASE`, we have something like the following:
+    //
+    //   |- ... ----------------- k_pos -----------------|  (old key pos, of a later key in the node)
+    //   |- ... - old_end -|
+    //                     |-- k_pos.sub_left(old_end) --|  (offset)
+    //   |- ... --- new_end ---|
+    //                         |-- k_pos.sub_left(old_end) --|  (offset, shifted)
+    //   |- ... - k_pos.sub_left(old_end).add_left(new_end) -|  (new key pos)
+    //
+    // So we have a workable formula here for shifitng keys. The thing is, we'd to make this a
+    // single operation in the loop, in case the index type is complicated or the compiler has
+    // failed to optimize away the extra work.
+    //
+    // We're guaranteed by the directional arithmetic rules that the following is equivalent to
+    // the formula we got above:
+    //
+    //   k_pos.sub_left(old_end.sub_right(new_end))
+    //
+    // Of course, this is only valid if `new_end < old_end` -- so if `IS_INCREASE` is false.
+    // Naturally, there's a rephrasing for when `new_end > old_end`:
+    //
+    //   k_pos.add_left(new_end.sub_left(old_end))           FIXME: prove this?
+    //
+    // This one is to be used when `IS_INCREASE` is true.
+    //
+    // ---
+    //
+    // With both of these, we can use the const generics from IS_INCREASE to minimize the final
+    // amount of code that gets generated:
+    let old_end = pos.add_right(old_size);
+    let new_end = pos.add_right(new_size);
+
+    let abs_difference = match IS_INCREASE {
+        true => new_end.sub_left(old_end),
+        false => old_end.sub_right(new_end),
+    };
+
+    let recalculate = |k_pos: I| -> I {
+        match IS_INCREASE {
+            true => k_pos.add_left(abs_difference),
+            false => k_pos.sub_left(abs_difference),
+        }
+    };
+
+    // SAFETY: `set_key_poss_with` requires that `from` is not greater than the number of keys
+    // (just like this function). This is already guaranteed by the caller.
+    unsafe { node.set_key_poss_with(recalculate, from..) };
+}

--- a/src/tree/insert.rs
+++ b/src/tree/insert.rs
@@ -2,18 +2,25 @@
 
 use crate::param::{BorrowState, RleTreeConfig, SliceRefStore as _, SupportsInsert};
 use crate::{Cursor, Index, PathComponent, RleTree, Slice};
+use std::cell::Cell;
 use std::cmp::Ordering;
+use std::ops::ControlFlow;
 
+use super::fix::{self, MapOpUpdateState, MapState, OpUpdateState, TraverseUpdate};
+use super::fix::{shift_keys_auto, shift_keys_decrease, shift_keys_increase, ShiftKeys};
 use super::node::{self, borrow, ty, ChildOrKey, NodeHandle, SliceHandle, Type};
 use super::{search_step, NodeBox, SharedNodeBox, Side, SliceSize};
-use super::{shift_keys_auto, shift_keys_decrease, shift_keys_increase, ShiftKeys};
 
 #[cfg(test)]
-use crate::{MaybeDebug, NoDebugImpl};
+use crate::MaybeDebug;
 #[cfg(test)]
 use std::fmt::{self, Debug, Formatter};
 #[cfg(test)]
 use std::mem::size_of;
+
+///////////////////////////////////////////////
+// High-level entrypoint (lower-level below) //
+///////////////////////////////////////////////
 
 impl<I, S, P, const M: usize> RleTree<I, S, P, M>
 where
@@ -21,19 +28,29 @@ where
     S: Slice<I>,
     P: RleTreeConfig<I, S, M> + SupportsInsert<I, S, M>,
 {
-    /// (*Internal*) Abstraction over the core insertion algorithm
+    /// (*Internal*) Shared "outer core" implementation of the public insertion APIs
+    ///
+    /// ## Safety
+    ///
+    /// The returned [`SliceHandle`] is `Some` *if and only if* type `P` is [`AllowSliceRefs`].
+    /// This may be relied upon in unsafe code.
+    ///
+    /// [`AllowSliceRefs`]: crate::param::AllowSliceRefs
+    #[track_caller] // so that panics are on the function that was called.
     pub(super) fn insert_internal<'t, C: Cursor>(
         &'t mut self,
         cursor: C,
         idx: I,
         slice: S,
         size: I,
-    ) -> (C, SliceHandle<ty::Unknown, borrow::SliceRef, I, S, P, M>) {
+    ) -> (C, Option<SliceHandle<ty::Unknown, borrow::SliceRef, I, S, P, M>>) {
         // All non-trivial operations on this tree are a pain in the ass, and insertion is no
         // exception. We'll try to have comments explaining some of the more hairy stuff.
         //
-        // This function is mostly edge-case handling; all of the tree traversal & shfiting stuff
-        // is done in other functions.
+        // This function is mostly high-level edge-case handling; all of the tree traversal &
+        // shfiting stuff is done in other functions. The other lower-level functions are also
+        // exposed so that algorithms that - in their own edge cases - require insertion can use
+        // them.
 
         if idx > self.size() {
             panic!(
@@ -50,6 +67,11 @@ where
             // create a fresh tree and return:
             None => {
                 *self = Self::new(slice, size);
+                let cursor = Cursor::new_empty();
+                if !P::SLICE_REFS {
+                    return (cursor, None);
+                }
+
                 let root_ptr = &self.root.as_mut().unwrap().handle;
                 // SAFETY: We just created the root, so there can't be any conflicts to worry
                 // about. The returned handle is already known to have the same lifetime as `self`.
@@ -57,7 +79,7 @@ where
                 // single entry.
                 let value_handle =
                     unsafe { root_ptr.borrow().into_slice_handle(0).clone_slice_ref() };
-                return (Cursor::new_empty(), value_handle);
+                return (Cursor::new_empty(), Some(value_handle));
             }
         };
 
@@ -80,99 +102,66 @@ where
             owned_root.borrow_mut().remove_parent();
         }
 
-        // Now on to the body of the insertion algorithm: continually dropping down the tree until
-        // we find a match, then working the changes back up.
+        /////////////////////////////////////
+        // Body of the insertion algorithm //
+        /////////////////////////////////////
         //
-        // The comments describing this are in `PreInsertTraversalState::do_search_step`.
-        let mut downward_search_state: PreInsertTraversalState<C, I, S, P, M> =
-            PreInsertTraversalState {
-                cursor_iter: Some(cursor.into_path()),
-                node: owned_root.borrow_mut(),
-                target: idx,
-                adjacent_keys: AdjacentKeys { lhs: None, rhs: None },
+        // This is where the juicy bits happen
+        //
+        // (ok not *actually* here, but kinda nearby)
+        //
+        let insertion_point =
+            Self::find_insertion_point(owned_root.borrow_mut(), cursor.into_path(), idx);
+
+        // Inseriton algorith, Part 2: do the thing
+        let (post_insert_result, mut insertion) = if P::SLICE_REFS {
+            let mut insertion = None;
+            let mut u = unsafe { TraverseUpdate::apply_to_ref(&mut insertion) };
+            // SAFETY: `do_insert_full` requires that, if `insertion_point` is a `LeafInsert`, its
+            // `new_k_idx` is less than or equal to its `node`'s length, which is guaranteed by
+            // `find_insertion_point`.
+            let result = unsafe {
+                Self::do_insert_full(&mut root.refs_store, insertion_point, slice, size, &mut u)
             };
+            drop(u); // `u` borrows `insertion`, and would otherwise drop *after* we yield here
+            (result, insertion)
+        } else {
+            let mut u = TraverseUpdate::do_nothing;
+            // SAFETY: `do_insert_full` requires that, `insertion_point` is a `LeafInsert`, its
+            // `new_k_idx` is less than or equal to its `node`'s length, which is guaranteed by
+            // `find_insertion_point`.
+            let result = unsafe {
+                Self::do_insert_full(&mut root.refs_store, insertion_point, slice, size, &mut u)
+            };
+            (result, None)
+        };
 
-        let insertion_point = loop {
-            match downward_search_state.do_search_step() {
-                Err(further_down) => downward_search_state = further_down,
-                Ok(result) => break result,
+        let cursor = match post_insert_result {
+            PostInsertResult::Done(cursor) => cursor,
+            PostInsertResult::NewRoot { cursor, lhs, key, key_size, rhs } => {
+                // we need to get rid of `lhs` first, so that we've released the borrow when we
+                // access the root
+                let lhs_ptr = lhs.ptr();
+                debug_assert!(owned_root.ptr() == lhs_ptr);
+
+                // SAFETY: `make_new_parent` requires that `owned_root` and `rhs` not have any
+                // parent already and are at the same height, which is guaranteed by `NewRoot`
+                unsafe {
+                    owned_root.make_new_parent(&mut root.refs_store, key, key_size, rhs.take());
+                }
+
+                if P::SLICE_REFS && insertion.is_none() {
+                    insertion =
+                        Some(unsafe { root.handle.borrow().into_slice_handle(0).clone_slice_ref() })
+                }
+
+                cursor
             }
         };
 
-        let mut post_insert_result: PostInsertTraversalResult<C, I, S, P, M>;
-
-        post_insert_result = match insertion_point {
-            ChildOrKey::Child(leaf) => {
-                let join_result =
-                    Self::do_insert_try_join(&mut root.refs_store, slice, size, leaf.adjacent_keys);
-
-                match join_result {
-                    Ok(post_insert_state) => PostInsertTraversalResult::Continue(post_insert_state),
-                    // SAFETY: The function requires that the `NodeHandle` provided to it is a leaf
-                    // node. This is guaranteed by the `InsertSearchResult`, which says that it's
-                    // guaranteed a leaf node if `result` is `ChildOrKey::Child`. We're also
-                    // guaranteed that `c_idx` is within the appropriate bounds by
-                    // `InsertSearchResult`. The function has extra requirements if
-                    // `override_lhs_size` is not `None`, but those don't apply here.
-                    Err(slice) => unsafe {
-                        let res = Self::do_insert_no_join(
-                            &mut root.refs_store,
-                            leaf.node,
-                            leaf.new_k_idx,
-                            None,
-                            SliceSize { slice, size },
-                            None,
-                        );
-
-                        match res {
-                            Ok(r) => r,
-                            Err(mut bubble_state) => loop {
-                                match bubble_state.do_upward_step(&mut root.refs_store, None) {
-                                    Err(b) => bubble_state = b,
-                                    Ok(post_insert) => break post_insert,
-                                }
-                            },
-                        }
-                    },
-                }
-            }
-            ChildOrKey::Key(key) => {
-                Self::split_insert(&mut root.refs_store, key.handle, key.pos_in_key, slice, size)
-            }
-        };
-
-        // Propagate the size change up the tree
-        let (cursor, insertion) = loop {
-            match post_insert_result {
-                PostInsertTraversalResult::Continue(state) => {
-                    post_insert_result = state.do_upward_step()
-                }
-                PostInsertTraversalResult::Root { cursor, insertion } => break (cursor, insertion),
-                PostInsertTraversalResult::NewRoot {
-                    cursor,
-                    lhs,
-                    key,
-                    key_size,
-                    rhs,
-                    insertion,
-                } => {
-                    // we need to get rid of `lhs` first, so that we've released the borrow when we
-                    // access the root
-                    let lhs_ptr = lhs.ptr();
-                    debug_assert!(owned_root.ptr() == lhs_ptr);
-
-                    // SAFETY: `make_new_parent` requires that `owned_root` and `rhs` not have any
-                    // parent already and are at the same height, which is guaranteed by `NewRoot`
-                    unsafe {
-                        owned_root.make_new_parent(&mut root.refs_store, key, key_size, rhs.take());
-                    }
-                    let insertion = insertion.unwrap_or_else(|| unsafe {
-                        root.handle.borrow().into_slice_handle(0).clone_slice_ref()
-                    });
-                    break (cursor, insertion);
-                }
-            }
-        };
+        if P::SLICE_REFS && insertion.is_none() {
+            panic!("internal error: final insertion handle is `None` but P is `AllowSliceRefs`");
+        }
 
         // Release the mutable borrow we originally acquired. It doesn't matter whether we do this
         // before or after replacing from a shallow copy because shallow copies only exist with COW
@@ -196,33 +185,18 @@ where
     }
 }
 
-/// (*Internal*) Helper struct to carry information for [`insert_internal`] and related functions
-/// as we traverse down the tree to find an insertion point
-///
-/// [`insert_internal`]: RleTree::insert_internal
-struct PreInsertTraversalState<'t, C, I, S, P, const M: usize>
-where
-    C: Cursor,
-    P: RleTreeConfig<I, S, M>,
-{
-    /// If the provided cursor has not provided a bad hint yet, the remaining items in its iterator
-    cursor_iter: Option<<C as Cursor>::PathIter>,
-    /// The node at the top of the subtree we're looking in
-    node: NodeHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>,
-    /// The position relative to the start of `node`'s subtree that we're looking to insert at
-    target: I,
-    /// The keys to the immediate left and right of the traversal path so far
-    adjacent_keys: AdjacentKeys<'t, I, S, P, M>,
-}
+/////////////////////////////////////
+// Helper / State type definitions //
+/////////////////////////////////////
 
 /// (*Internal*) The result of a successful downward search for an insertion point, returned by
-/// [`PreInsertTraversalState::do_search_step`]
-type InsertSearchResult<'t, I, S, P, const M: usize> =
-    ChildOrKey<LeafInsert<'t, I, S, P, M>, SplitKeyInsert<'t, I, S, P, M>>;
+/// [`RleTree::find_insertion_point`]
+type InsertionPoint<'t, I, S, P, const M: usize> =
+    ChildOrKey<EdgeInsert<'t, I, S, P, M>, SplitKeyInsert<'t, I, S, P, M>>;
 
-/// (*Internal*) Component of an [`InsertSearchResult`] specific to inserting *between* keys in a
+/// (*Internal*) Component of an [`InsertionPoint`] specific to inserting *between* keys in a
 /// leaf
-struct LeafInsert<'t, I, S, P: RleTreeConfig<I, S, M>, const M: usize> {
+struct EdgeInsert<'t, I, S, P: RleTreeConfig<I, S, M>, const M: usize> {
     /// The leaf node that the value should be inserted into
     node: NodeHandle<ty::Leaf, borrow::Mut<'t>, I, S, P, M>,
     /// The keys to the immediate left and right of the insertion point
@@ -235,7 +209,7 @@ struct LeafInsert<'t, I, S, P: RleTreeConfig<I, S, M>, const M: usize> {
     new_k_idx: u8,
 }
 
-/// (*Internal*) Component of an [`InsertSearchResult`] for when an insertion point is found in the
+/// (*Internal*) Component of an [`InsertionPoint`] for when an insertion point is found in the
 /// middle of an existing key
 ///
 /// In this case, the key must be split in order to perform the insertion.
@@ -285,13 +259,19 @@ where
     /// split it
     old_size: I,
 
-    /// Handle to the slice that was inserted, plus which one of `lhs` or `rhs` it's in, only if it
-    /// the inserted slice is actually in `key`
+    /// If provided, `shift_lhs` overrides the position and size of `lhs` during size calculations
+    /// for [`do_upward_step`]
     ///
-    /// ## Safety
+    /// Setting `shift_lhs` allows the default size calcuation of the left-hand node's size
+    /// (usually done using `self.old_size`) to be overridden
     ///
-    /// The slice behind the handle *cannot* be accessed until the borrow at `node` is released.
-    insertion: Option<BubbledInsertion<I, S, P, M>>,
+    /// [`do_upward_step`]: Self::do_upward_step
+    shift_lhs: Option<BubbleLhs<I>>,
+
+    /// If the inserted slice isn't `key`, then a marker for which one of `lhs` or `rhs` it's in
+    ///
+    /// This is kept only so that we can update the cursor on processing the upward step.
+    insertion_side: Option<Side>,
 
     /// Cursor representing the path to the insertion
     ///
@@ -300,155 +280,39 @@ where
     partial_cursor: C,
 }
 
-/// (*Internal*) An inserted [`SliceHandle`] and where to find it ; for [`BubbledInsertState`]
-struct BubbledInsertion<I, S, P: RleTreeConfig<I, S, M>, const M: usize> {
-    /// Flag for which child the bubbled insertion is in
-    ///
-    /// This is tracked so that we can accurately update the cursor as we go up the tree.
-    side: Side,
-    /// Handle to the insertion
-    handle: SliceHandle<ty::Unknown, borrow::SliceRef, I, S, P, M>,
-}
-
-/// (*Internal*) Helper struct to carry information for [`insert_internal`] and related functions
-/// as we traverse up the tree to propagate insertion results
+/// (*Internal*) The end result of running the "full" insertion algorithm, minus the cleanup that
+/// happens afterwards
 ///
-/// [`insert_internal`]: RleTree::insert_internal
-struct PostInsertTraversalState<'t, C, I, S, P, const M: usize>
-where
-    P: RleTreeConfig<I, S, M>,
-{
-    /// Handle to the slice that was inserted
-    ///
-    /// ## Safety
-    ///
-    /// The slice behind this handle *cannot* be accessed until the borrow at `node` is released.
-    inserted_slice: SliceHandle<ty::Unknown, borrow::SliceRef, I, S, P, M>,
-
-    /// The key or child containing the insertion as we're traversing upwards, alongside the typed
-    /// node containing it
-    ///
-    /// For keys that are positioned after this child or key (i.e. at a greater index), their
-    /// positions within the node can be updated with:
-    ///
-    /// ```text
-    /// |- ... -------------- key --------------|   (original position of a key after `child_or_key`)
-    /// |- ... --- pos ---|                         (node-relative `child_or_key` position)
-    ///                   |- key.sub_left(pos) -|
-    ///                   |---- new_size ----|
-    ///                                      |- key.sub_left(pos) -|  (same size as above, shifted)
-    ///                   |- key.sub_left(pos).add_left(new_size) -|
-    /// |- ... - key.sub_left(pos).add_left(new_size).add_left(pos) -|  (new key position)
-    /// ```
-    ///
-    /// The final result, `key.sub_left(pos).add_left(new_size).add_left(pos)` can largely be
-    /// tracked by a running total of the distance from each key back to the insertion child/key,
-    /// adding the distance between keys each time. So the value is then
-    /// `key.sub_left(pos).add_left(sum)`.
-    ///
-    /// This careful dance is only there because we have to make sure that we uphold the guarantees
-    /// we provide for directional arithmetic -- we can't just `add_left(size)` because that's not
-    /// where the slice is.
-    ///
-    /// If the usage around this is written in *just* the right way, the compiler should realize
-    /// what's going on and optimize it to (approximately) `key += size`.
-    child_or_key: ChildOrKey<
-        // Child: must be internal
-        (u8, NodeHandle<ty::Internal, borrow::Mut<'t>, I, S, P, M>),
-        // Key: unknown type
-        (u8, NodeHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>),
-    >,
-
-    /// Optional override in case the start position of the size change is not equal to the start
-    /// position given by `child_or_key`
-    override_pos: Option<I>,
-
-    /// The old size of the child or key containing the insertion
-    old_size: I,
-    /// The new size of the child or key containing the insertion. This is provided separately so
-    /// that it can be updated *after* the original size has been recorded
-    new_size: I,
-
-    /// Cursor representing the path to the deepest node containing the insertion
-    ///
-    /// This cursor is often empty.
-    ///
-    /// ---
-    ///
-    /// In theory, it's entirely possible to use `inserted_slice` to build a cursor after the fact
-    /// and get the exact path to the insertion. In practice, this involves doing a second upwards
-    /// tree traversal, so we opt for an imperfect "good enough" solution that minimizes additional
-    /// costs.
-    partial_cursor: C,
-}
-
-/// (*Internal*) The result of an upward step from [`PostInsertTraversalState::do_upward_step`]
-///
-/// This type is extracted out in order to allow a common interface for functions that may need to
-/// handle their own post-insert traversals
-enum PostInsertTraversalResult<'t, C, I, S, P, const M: usize>
-where
-    P: RleTreeConfig<I, S, M>,
-{
-    /// Traversal has not yet gone through the root (although it *may* be this field's `node`), and
-    /// so should continue
-    Continue(PostInsertTraversalState<'t, C, I, S, P, M>),
-    /// Traversal has finished, with all nodes updated. The cursor and reference to the slice have
-    /// been returned
-    Root {
-        cursor: C,
-        insertion: SliceHandle<ty::Unknown, borrow::SliceRef, I, S, P, M>,
-    },
-    /// The insertion resulted in creating a new root node, but that needs to be handled by
-    /// [`insert_internal`], because no other method has access to the existing root with an
-    /// `Owned` borrow
-    ///
-    /// [`insert_internal`]: RleTree::insert_internal
+/// This type is primarily returned by [`RleTree::do_insert_full`].
+enum PostInsertResult<'t, C, I, S, P: RleTreeConfig<I, S, M>, const M: usize> {
+    /// No more changes to the tree are necessary - here's the [`Cursor`]
+    Done(C),
     NewRoot {
         /// The *completed* cursor to the insertion, taking into account the locations that `lhs`
-        /// and `rhs` will have.
+        /// and `rhs` will have
         cursor: C,
-        /// The current root node, which will become the left-hand child in the new root
+        /// Current root node, which will become the left-hand child of the new root
         lhs: NodeHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>,
         /// Key to be inserted between `lhs` and `rhs`
         key: node::Key<I, S, P, M>,
+        /// Size of `key`
         key_size: I,
-        /// New, right-hand node
+        /// A new node, which will become the right-hand child of the new root
         rhs: NodeBox<ty::Unknown, I, S, P, M>,
-        /// If the insertion is not `key`, then a handle on the inserted slice
-        insertion: Option<SliceHandle<ty::Unknown, borrow::SliceRef, I, S, P, M>>,
     },
 }
 
-#[cfg(test)]
-impl<'t, C, I, S, P, const M: usize> Debug for PreInsertTraversalState<'t, C, I, S, P, M>
-where
-    C: Cursor,
-    P: RleTreeConfig<I, S, M>,
-{
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let mut s = f.debug_struct("PreInsertTraversalState");
-        if size_of::<C::PathIter>() != 0 {
-            let _ = match self.cursor_iter.as_ref() {
-                Some(it) => s.field("cursor_iter", &Some(it.fallible_debug())),
-                None => s.field("cursor_iter", &(None as Option<()>)),
-            };
-        }
-
-        s.field("node", &self.node)
-            .field("target", self.target.fallible_debug())
-            .field("adjacent_keys", &self.adjacent_keys)
-            .finish()
-    }
-}
+/////////////////////////////
+// `Debug` implementations //
+/////////////////////////////
 
 #[cfg(test)]
-impl<'t, I, S, P, const M: usize> Debug for LeafInsert<'t, I, S, P, M>
+impl<'t, I, S, P, const M: usize> Debug for EdgeInsert<'t, I, S, P, M>
 where
     P: RleTreeConfig<I, S, M>,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_struct("LeafInsert")
+        f.debug_struct("EdgeInsert")
             .field("node", &self.node)
             .field("adjacent_keys", &self.adjacent_keys)
             .field("new_k_idx", &self.new_k_idx)
@@ -494,170 +358,49 @@ where
             .field("key_size", self.key_size.fallible_debug())
             .field("rhs", &self.rhs)
             .field("old_size", &self.old_size.fallible_debug())
-            .field("insertion", &self.insertion)
+            .field("insertion_side", &self.insertion_side)
             .finish()
     }
 }
 
 #[cfg(test)]
-impl<I, S, P: RleTreeConfig<I, S, M>, const M: usize> Debug for BubbledInsertion<I, S, P, M> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_struct("BubbledInsertion")
-            .field("side", &self.side)
-            .field("handle", &NoDebugImpl)
-            .finish()
-    }
-}
-
-#[cfg(test)]
-impl<'t, C, I, S, P, const M: usize> Debug for PostInsertTraversalState<'t, C, I, S, P, M>
-where
-    P: RleTreeConfig<I, S, M>,
-{
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let (idx_name, idx, node) = match &self.child_or_key {
-            ChildOrKey::Key((k_idx, node)) => ("key_idx", k_idx, node),
-            ChildOrKey::Child((c_idx, node)) => ("child_idx", c_idx, node.untyped_ref()),
-        };
-
-        f.debug_struct("PostInsertTraversalState")
-            .field("node", node)
-            .field(idx_name, idx)
-            .field("override_pos", self.override_pos.fallible_debug())
-            .field("old_size", self.old_size.fallible_debug())
-            .field("new_size", self.new_size.fallible_debug())
-            .finish()
-    }
-}
-
-#[cfg(test)]
-impl<'t, C, I, S, P, const M: usize> Debug for PostInsertTraversalResult<'t, C, I, S, P, M>
+impl<'t, C, I, S, P, const M: usize> Debug for PostInsertResult<'t, C, I, S, P, M>
 where
     P: RleTreeConfig<I, S, M>,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Self::Continue(state) => f.debug_tuple("Continue").field(&state).finish(),
-            Self::Root { cursor, insertion } => {
-                let mut s = f.debug_struct("Root");
+            PostInsertResult::Done(cursor) => {
+                let mut s = f.debug_struct("Done");
                 if size_of::<C>() != 0 {
                     s.field("cursor", cursor.fallible_debug());
                 }
-                s.field("insertion", insertion).finish()
+                s.finish()
             }
-            Self::NewRoot { lhs, key, key_size, rhs, .. } => {
+            PostInsertResult::NewRoot { cursor, lhs, key, key_size, rhs } => {
                 let mut s = f.debug_struct("NewRoot");
-                s.field("lhs", &lhs)
-                    .field("key", &key)
+
+                if size_of::<C>() != 0 {
+                    s.field("cursor", cursor.fallible_debug());
+                }
+
+                s.field("lhs", lhs)
+                    .field("key", key)
                     .field("key_size", key_size.fallible_debug())
-                    .field("rhs", &rhs)
+                    .field("rhs", rhs)
                     .finish()
             }
         }
     }
 }
 
-impl<'t, C, I, S, P, const M: usize> PreInsertTraversalState<'t, C, I, S, P, M>
-where
-    C: Cursor,
-    I: Index,
-    S: Slice<I>,
-    P: SupportsInsert<I, S, M> + RleTreeConfig<I, S, M>,
-{
-    /// Performs a single step of a downward search for an insertion point
-    fn do_search_step(mut self) -> Result<InsertSearchResult<'t, I, S, P, M>, Self> {
-        let cursor_hint = self.cursor_iter.as_mut().and_then(|iter| iter.next());
+/////////////////////////////////
+// Private(ish) implementation //
+/////////////////////////////////
 
-        let mut search_result = search_step(self.node.borrow(), cursor_hint, self.target);
-        // If the result was the start of a key, we actually want to insert in the child
-        // immediately before it.
-        if let ChildOrKey::Key((k_idx, k_pos)) = search_result {
-            if k_pos == self.target {
-                // SAFETY: `k_idx` is guaranteed to be a valid key index, so it's therefore a valid
-                // child index as well.
-                let child_size = unsafe { self.node.try_child_size(k_idx).unwrap_or(I::ZERO) };
-                let child_pos = k_pos.sub_right(child_size);
-                search_result = ChildOrKey::Child((k_idx, child_pos));
-            }
-        }
-
-        let hint_was_good = matches!(
-            (search_result, cursor_hint),
-            (ChildOrKey::Child((c_idx, _)), Some(h)) if c_idx == h.child_idx
-        );
-
-        if !hint_was_good {
-            self.cursor_iter = None;
-        }
-
-        match search_result {
-            // A successful result. We don't need the adjacent keys anymore because the insertion
-            // will split `key_idx`
-            ChildOrKey::Key((k_idx, k_pos)) => {
-                // SAFETY: The call to `find_insertion_point` guarantees that return values of
-                // `ChildOrKey::Key` contains an index within the bounds of the node's keys.
-                let handle = unsafe { self.node.into_slice_handle(k_idx) };
-
-                Ok(ChildOrKey::Key(SplitKeyInsert {
-                    handle,
-                    pos_in_key: self.target.sub_left(k_pos),
-                }))
-            }
-            // An index between keys -- we don't yet know if it's an internal or leaf node.
-            ChildOrKey::Child((child_idx, child_pos)) => {
-                // Later on, we'll distinguish the type of node, but either way we need to update
-                // the adjacent keys:
-                if S::MAY_JOIN {
-                    // The key to the left of child index `i` is at key index `i - 1`. We should
-                    // only override the left-hand adjacent key if this child isn't the first one
-                    // in its node:
-                    if let Some(ki) = child_idx.checked_sub(1) {
-                        // SAFETY: the return from `find_insertion_point` guarantees that the child
-                        // index is within bounds, relative to the number of keys (i.e. less than
-                        // key len + 1). So subtracting 1 guarantees a valid key index.
-                        self.adjacent_keys.lhs = Some(unsafe { self.node.split_slice_handle(ki) });
-                    }
-
-                    // `child_idx` is the rightmost child if it's *equal* to `node.len_keys()`.
-                    // Anything less means we should get the key to the right of it.
-                    if child_idx < self.node.leaf().len() {
-                        // SAFETY: same as above. The right-hand side key is *at* key index
-                        // `child_idx` because child indexing starts left of key indexing
-                        self.adjacent_keys.rhs =
-                            Some(unsafe { self.node.split_slice_handle(child_idx) });
-                    }
-                }
-
-                match self.node.into_typed() {
-                    // If it's a leaf node, we've found an insertion point between two keys
-                    Type::Leaf(leaf) => {
-                        return Ok(ChildOrKey::Child(LeafInsert {
-                            node: leaf,
-                            adjacent_keys: self.adjacent_keys,
-                            // Two things here: (a) child indexes are offset to occur in the gaps
-                            // *before* the key of the same index (i.e. child0, then key0, then child1)
-                            // and (b) the guarantees of `find_insertion_point` mean that th
-                            new_k_idx: child_idx,
-                        }));
-                    }
-                    // Otherwise, we should keep going:
-                    Type::Internal(internal) => {
-                        let pos_in_child = self.target.sub_left(child_pos);
-                        self.target = pos_in_child;
-                        // SAFETY: This function only requires that `child_idx` be in bounds. This
-                        // is condition is guaranteed by `find_insertion_point`.
-                        self.node = unsafe { internal.into_child(child_idx) };
-                        Err(self)
-                    }
-                }
-            }
-        }
-    }
-}
-
-// This block is only private stuff; doc links can reference other private stuff
 #[allow(rustdoc::private_intra_doc_links)]
 /// Internal-only helper functions for implementing [`insert_internal`](RleTree::insert_internal)
+/// and machinery for other algorithms that require insertion.
 impl<I, S, P, const M: usize> RleTree<I, S, P, M>
 where
     I: Index,
@@ -670,27 +413,99 @@ where
     // Purely serves to dispatch based on enum variants. //
     ///////////////////////////////////////////////////////
 
-    /// Inserts the slice into the key, splitting it and attempting to re-join
-    fn split_insert<'t, C: Cursor>(
+    /// (*Internal*) Performs an insertion at the given `insertion_point`, returning the result of
+    /// completing the insertion
+    ///
+    /// ## Safety
+    ///
+    /// If `insertion_point` is a `Child`, then the [`EdgeInsert`]'s `new_k_idx` must be less than
+    /// or equal to its `node`'s length.
+    unsafe fn do_insert_full<'t, C: Cursor>(
         store: &mut P::SliceRefStore,
-        mut key_handle: SliceHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>,
-        split_pos: I,
+        insertion_point: InsertionPoint<'t, I, S, P, M>,
+        slice: S,
+        size: I,
+        updates_callback: &mut impl FnMut(TraverseUpdate<I, S, P, M>),
+    ) -> PostInsertResult<'t, C, I, S, P, M> {
+        match insertion_point {
+            // SAFETY: `do_insert_full_edge` requires that `edge_ins.new_k_idx` is less than or
+            // equal to `edge_ins.node.leaf().len()`, which is guaranteed by the safety
+            // requirements for this function.
+            ChildOrKey::Child(edge_ins) => unsafe {
+                Self::do_insert_full_edge(store, edge_ins, slice, size, updates_callback)
+            },
+            ChildOrKey::Key(split_ins) => {
+                Self::do_insert_full_split_key(store, split_ins, slice, size, updates_callback)
+            }
+        }
+    }
+
+    /// (*Internal*) Performs an insertion between two keys in a leaf node, as specified by the
+    /// [`EdgeInsert`].
+    ///
+    /// Returns the result of completing the insertion.
+    ///
+    /// ## Safety
+    ///
+    /// This function requires that `insert.new_k_idx` is less than or equal to
+    /// `insert.node.leaf().len()`.
+    unsafe fn do_insert_full_edge<'t, C: Cursor>(
+        store: &mut P::SliceRefStore,
+        insert: EdgeInsert<'t, I, S, P, M>,
+        slice: S,
+        size: I,
+        updates_callback: &mut impl FnMut(TraverseUpdate<I, S, P, M>),
+    ) -> PostInsertResult<'t, C, I, S, P, M> {
+        unsafe { weak_assert!(insert.new_k_idx <= insert.node.leaf().len()) }
+
+        match Self::do_insert_full_edge_try_join(
+            store,
+            slice,
+            size,
+            insert.adjacent_keys,
+            updates_callback,
+        ) {
+            Ok(update_state) => update_state,
+            // SAFETY: `do_insert_full_edge_no_join` requires that `insert.new_k_idx` is less than
+            // or equal to `insert.node.leaf().len()`, which is guaranteed by the
+            #[rustfmt::skip]
+            Err(slice) => unsafe {
+                Self::do_insert_full_edge_no_join(
+                    store,
+                    insert.node,
+                    insert.new_k_idx, None,
+                    SliceSize { slice, size }, None,
+                    updates_callback,
+                    BubbledInsertState::identity(),
+                )
+            },
+        }
+    }
+
+    /// (*Internal*) Performs an insertion in the middle of a key by splitting it, as specified by
+    /// the [`SplitKeyInsert`].
+    ///
+    /// Returns the result of completing the insertion.
+    fn do_insert_full_split_key<'t, C: Cursor>(
+        store: &mut P::SliceRefStore,
+        mut info: SplitKeyInsert<'t, I, S, P, M>,
         slice: S,
         slice_size: I,
-    ) -> PostInsertTraversalResult<'t, C, I, S, P, M> {
-        let key_size = key_handle.slice_size();
+        updates_callback: &mut impl FnMut(TraverseUpdate<I, S, P, M>),
+    ) -> PostInsertResult<'t, C, I, S, P, M> {
+        let key_size = info.handle.slice_size();
 
-        let rhs = key_handle.with_slice(|slice| slice.split_at(split_pos));
-        let rhs_size = key_size.sub_left(split_pos);
+        let rhs = info.handle.with_slice(|slice| slice.split_at(info.pos_in_key));
+        let rhs_size = key_size.sub_left(info.pos_in_key);
 
-        let (mut lhs_handle, lhs_size) = (key_handle, split_pos);
+        let (mut lhs_handle, lhs_size) = (info.handle, info.pos_in_key);
 
         // Fast path: no need to try joining.
         if !S::MAY_JOIN {
             let (mid, mid_size) = (slice, slice_size);
             let fst = SliceSize::new(mid, mid_size);
             let snd = SliceSize::new(rhs, rhs_size);
-            return Self::insert_rhs(store, lhs_handle, lhs_size, fst, Some(snd));
+            return Self::insert_rhs(store, lhs_handle, lhs_size, fst, Some(snd), updates_callback);
         }
 
         // Slow path: try to join with both sides.
@@ -716,35 +531,47 @@ where
             Ok(new) if joined_with_lhs => {
                 lhs_handle.fill_hole(new);
 
-                PostInsertTraversalResult::Continue(PostInsertTraversalState {
-                    // SAFETY: `clone_slice_ref` requires that we not access `inserted_slice` until
-                    // the borrow used by `node` is released. This is mirrored in the safety
-                    // conditions in `PostInsertTraversalState` itself.
-                    inserted_slice: unsafe { lhs_handle.clone_slice_ref() },
+                let inserted_slice = &lhs_handle;
+                updates_callback(TraverseUpdate::insert(inserted_slice));
+
+                let post_op_state = OpUpdateState {
                     child_or_key: ChildOrKey::Key((lhs_handle.idx, lhs_handle.node)),
                     override_pos: None,
                     old_size: lhs_size.add_right(rhs_size),
                     new_size: mid_size.add_right(rhs_size),
                     partial_cursor: C::new_empty(),
-                })
+                };
+
+                let mapper = OpUpdateState::identity();
+                let final_cursor = post_op_state.finish(mapper, None);
+                PostInsertResult::Done(final_cursor)
             }
             // Couldn't join with lhs, but slice + rhs joined. Still need to insert those:
             Ok(new) => {
                 let size = mid_size.add_right(rhs_size);
-                Self::insert_rhs(store, lhs_handle, lhs_size, SliceSize::new(new, size), None)
+                Self::insert_rhs(
+                    store,
+                    lhs_handle,
+                    lhs_size,
+                    SliceSize::new(new, size),
+                    None,
+                    updates_callback,
+                )
             }
             // Couldn't join with rhs, but did join with lhs. Still need to insert rhs:
             Err((l, r)) if joined_with_lhs => {
                 lhs_handle.fill_hole(l);
                 let fst = SliceSize::new(r, rhs_size);
-                Self::insert_rhs(store, lhs_handle, mid_size, fst, None)
+                updates_callback(TraverseUpdate::insert(&lhs_handle));
+                let mut new_callback = TraverseUpdate::skip_insertions(updates_callback);
+                Self::insert_rhs(store, lhs_handle, mid_size, fst, None, &mut new_callback)
             }
             // Couldn't join with either lhs or rhs. Need to insert both original slice AND new rhs
             Err((m, r)) => {
                 let fst = SliceSize::new(m, mid_size);
                 let snd = SliceSize::new(r, rhs_size);
 
-                Self::insert_rhs(store, lhs_handle, lhs_size, fst, Some(snd))
+                Self::insert_rhs(store, lhs_handle, lhs_size, fst, Some(snd), updates_callback)
             }
         }
     }
@@ -760,20 +587,25 @@ where
     /// `Err(slice)` joining fails
     ///
     /// If joining succeeds, the insertion is processed upwards until all structural changes to the
-    /// tree are resolved, and then the [`PostInsertTraversalState`] is returned.
-    fn do_insert_try_join<'t, C: Cursor>(
-        store: &mut <P as RleTreeConfig<I, S, M>>::SliceRefStore,
+    /// tree are resolved, and the [`PostInsertResult`] is returned. Otherwise, `Err(slice)` is
+    /// returned.
+    ///
+    /// We return `Err` instead of handling that case as well because there's many code paths that
+    /// can lead to being unable to join to anything, so it's easier to
+    fn do_insert_full_edge_try_join<'t, C: Cursor>(
+        store: &mut P::SliceRefStore,
         slice: S,
         slice_size: I,
         adjacent_keys: AdjacentKeys<'t, I, S, P, M>,
-    ) -> Result<PostInsertTraversalState<'t, C, I, S, P, M>, S> {
+        updates_callback: &mut impl FnMut(TraverseUpdate<I, S, P, M>),
+    ) -> Result<PostInsertResult<'t, C, I, S, P, M>, S> {
         // Broadly speaking, there's four cases here:
         //  1. `slice` doesn't join with either of `adjacent_keys` -- returns Err(slice)
         //  2. `slice` only joins with `adjacent_keys.lhs`
         //  3. `slice` only joins with `adjacent_keys.rhs`
         //  4. `slice` joins with both keys
-        // The logic for cases 2 & 3 are essentially the same, so our labeled loop below produces a
-        // value to be handled for those cases and returns for 1 & 4.
+        // The logic for cases 2 & 3 are essentially the same, so our labeled block below produces
+        // a value to be handled for those cases and returns for 1 & 4.
 
         // Fast path.
         if !S::MAY_JOIN {
@@ -785,10 +617,12 @@ where
 
         // TODO: This code could be more concise, probably by merging `None` with "couldn't join".
         // That *may* be slightly more difficult to reason about, though.
-        let (handle, old_size, new_size) = 'single_join: loop {
+        let (handle, old_size, new_size) = 'single_join: {
             match (lhs_with_size, rhs_with_size) {
                 // Nothing to do.
-                (None, None) => return Err(slice),
+                (None, None) => unreachable!(
+                    "edges have at least one key on either side because the tree is not empty"
+                ),
 
                 // Try to join with `lhs`. If that succeeds, break 'single_join. Otherwise, return
                 // Err(slice).
@@ -861,8 +695,13 @@ where
                             // `lhs`.
                             rhs.redirect_to(&lhs, store);
 
+                            // Before we perform the rest of the deletion, send `updates_callback`
+                            // a signal that the inserted value was merged with `lhs`:
+                            updates_callback(TraverseUpdate::insert(&lhs));
+
                             let new_lhs_size = mid_size.add_right(rhs_size);
                             return Ok(Self::handle_join_deletion(
+                                store,
                                 lhs,
                                 lhs_size,
                                 new_lhs_size,
@@ -889,26 +728,33 @@ where
             }
         };
 
-        Ok(PostInsertTraversalState {
-            // SAFETY: `clone_slice_ref` requires that we not access `inserted_slice` until the
-            // borrow used by `node` is released. This is mirrored in the safety conditions in
-            // `PostInsertTraversalState` itself.
-            inserted_slice: unsafe { handle.clone_slice_ref() },
+        // Set the initial insertion
+        updates_callback(TraverseUpdate::insert(&handle));
+
+        let update_state = OpUpdateState {
             child_or_key: ChildOrKey::Key((handle.idx, handle.node)),
             override_pos: None,
             old_size,
             new_size,
             partial_cursor: C::new_empty(),
-        })
+        };
+
+        let mapper = OpUpdateState::identity();
+        let cursor = update_state.finish(mapper, None);
+        Ok(PostInsertResult::Done(cursor))
     }
 
-    /// (*Internal*) Performs an insertion into the leaf node, with the key(s) at `new_key_idx`
+    /// (*Internal*) Tries to insert the slice(s) _without_ joining with adjacent keys
     ///
     /// A second key to insert may also be provided, which will be inserted after `fst`. If a
-    /// second key is provided, only the first key will be used for the slice reference.
+    /// second key is provided, only the first key will be used for the slice reference. (I.e.,
+    /// only the first key will generate an initial [`TraverseUpdate::PutBack`] event)
     ///
     /// `override_lhs_size` is used exclusively by [`insert_rhs`] in order to ensure that the key
     /// positions (and resulting increases in size) are correct from the moment of insertion.
+    ///
+    /// `updates_callback` is called with a `TraverseUpdate::Insertion` exactly once by this
+    /// function, for `fst` -- regardless of whether `snd` is provided.
     ///
     /// ## Safety
     ///
@@ -916,15 +762,16 @@ where
     /// `override_lhs_size` is provided, `new_key_idx != 0`.
     ///
     /// [`insert_rhs`]: Self::insert_rhs
-    unsafe fn do_insert_no_join<'t, C: Cursor>(
+    unsafe fn do_insert_full_edge_no_join<'m, 't: 'm, C: Cursor>(
         store: &mut P::SliceRefStore,
         mut node: NodeHandle<ty::Leaf, borrow::Mut<'t>, I, S, P, M>,
         new_key_idx: u8,
         override_lhs_size: Option<I>,
         fst: SliceSize<I, S>,
         snd: Option<SliceSize<I, S>>,
-    ) -> Result<PostInsertTraversalResult<'t, C, I, S, P, M>, BubbledInsertState<'t, C, I, S, P, M>>
-    {
+        updates_callback: &mut impl FnMut(TraverseUpdate<I, S, P, M>),
+        state_map: <BubbledInsertState<'t, C, I, S, P, M> as MapState>::Map<'m>,
+    ) -> PostInsertResult<'t, C, I, S, P, M> {
         // SAFETY: Guaranteed by caller
         unsafe {
             weak_assert!(new_key_idx <= node.leaf().len());
@@ -937,21 +784,24 @@ where
             None => (0, fst.size),
         };
 
-        // "hard" case: split the node on insertion:
-        //
-        // SAFETY: `do_insert_no_join_split` requires the same things that this function does, and
-        // *also* the exact condition above.
         if node.leaf().len() >= node.leaf().max_len() - one_if_snd {
-            unsafe {
-                return Self::do_insert_no_join_split(
+            // "hard" case: split the node on insertion:
+            //
+            // SAFETY: `do_insert_no_join_split` requires the same things that this function does,
+            // and *also* the exact condition above:
+            let bubble_state = unsafe {
+                Self::do_insert_full_edge_no_join_split(
                     store,
                     node,
                     new_key_idx,
                     override_lhs_size,
                     fst,
                     snd,
-                );
-            }
+                    updates_callback,
+                )
+            };
+            let early_exit = None;
+            return bubble_state.finish(store, state_map, updates_callback, early_exit);
         }
 
         // Otherwise, "easy" case: just add the slice(s) to the node
@@ -1005,13 +855,13 @@ where
         // SAFETY: we just inserted `new_slice_idx`, so it's a valid key index.
         let slice_handle = unsafe { node.into_slice_handle(new_key_idx) };
 
+        // Set the initial insertion:
+        updates_callback(TraverseUpdate::insert(&slice_handle));
+
         // We can allow `PostInsertTraversalState::do_upward_step` to shift the key positions,
         // because the "current" size of the newly inserted slice is zero, so the increase from
         // zero to `slice_size` in `do_upward_step` will have the desired effect anyways.
-        return Ok(PostInsertTraversalResult::Continue(PostInsertTraversalState {
-            // SAFETY: `clone_slice_ref` requires that the handle isn't used until after `node` is
-            // dropped, which is guaranteed by the safety bounds of `inserted_slice`.
-            inserted_slice: unsafe { slice_handle.clone_slice_ref().erase_type() },
+        let post_op_state = OpUpdateState {
             child_or_key: ChildOrKey::Key((
                 new_key_idx + one_if_snd,
                 slice_handle.node.erase_type(),
@@ -1020,32 +870,42 @@ where
             old_size,
             new_size,
             partial_cursor: C::new_empty(),
-        }));
+        };
+
+        let final_cursor = post_op_state.finish(state_map.post_op, None);
+        PostInsertResult::Done(final_cursor)
     }
 
-    /// (*Internal*) Handles the deletion of `rhs` due to insertion that joins with `lhs`
+    /// (*Internal*) Completes an insertion that resulted in the deletion of a slice
     ///
-    /// It's expected that there will be a hole at `rhs`, from the value that had joined with
-    /// `lhs`.
-    fn handle_join_deletion<'b, C: Cursor>(
-        lhs: SliceHandle<ty::Unknown, borrow::Mut<'b>, I, S, P, M>,
+    /// This can happen when the two slices on either side of the insertion are able to join,
+    /// turning two values (plus one) into one.
+    ///
+    /// This function expects, without checking, that `rhs.is_hole()` is true.
+    fn handle_join_deletion<'t, C: Cursor>(
+        store: &mut P::SliceRefStore,
+        lhs: SliceHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>,
         old_lhs_size: I,
         new_lhs_size: I,
-        rhs: SliceHandle<ty::Unknown, borrow::Mut<'b>, I, S, P, M>,
-        old_rhs_size: I,
-    ) -> PostInsertTraversalState<'b, C, I, S, P, M> {
+        rhs: SliceHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>,
+        rhs_size: I,
+    ) -> PostInsertResult<'t, C, I, S, P, M> {
+        // todo: Pending deletion implementation.
         todo!()
     }
 
     /// Inserts the slice to the immediate right of another slice, recording the changed size from
     /// both the left (present) and right (inserted) sides
-    fn insert_rhs<'b, C: Cursor>(
+    ///
+    /// This method calls `updates_callback` with `TraverseUpdate::Insertion` only for `fst`.
+    fn insert_rhs<'t, C: Cursor>(
         store: &mut P::SliceRefStore,
-        right_of: SliceHandle<ty::Unknown, borrow::Mut<'b>, I, S, P, M>,
+        right_of: SliceHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>,
         new_lhs_size: I,
         fst: SliceSize<I, S>,
         snd: Option<SliceSize<I, S>>,
-    ) -> PostInsertTraversalResult<'b, C, I, S, P, M> {
+        updates_callback: &mut impl FnMut(TraverseUpdate<I, S, P, M>),
+    ) -> PostInsertResult<'t, C, I, S, P, M> {
         // If we're inserting to the right of the particular slice, we have to traverse down to the
         // leftmost leaf in the child right of `right_of` (if it's not yet in a leaf).
         //
@@ -1079,10 +939,105 @@ where
             }
         };
 
+        let mut map_cursor;
+        let mut map_shift_lhs;
+        let mut map_sizes;
+        let handled_shift = Cell::new(false);
+
         let leaf_height = next_leaf.height(); // stored for later
-        let override_lhs_size = match lhs_height == leaf_height {
-            false => None,
-            true => Some(new_lhs_size),
+        let (override_lhs_size, mapper) = match lhs_height == leaf_height {
+            true => (Some(new_lhs_size), BubbledInsertState::identity()),
+            false => {
+                map_cursor = |node: &NodeHandle<_, _, _, _, _, M>, cursor| match node.height()
+                    == lhs_height
+                {
+                    false => cursor,
+                    // FIXME: there's some extra handling needed here when the cursor isn't on the
+                    // same side as the inserted value. Also this isn't correct when the value that
+                    // we *should* point to is currently removed. Tracking that requires modifying
+                    // `updates_callback` as well.
+                    true => C::new_empty(),
+                };
+
+                // If the bubble state *will* change the node at the height of `lhs`, then we need
+                // to change the way that it internally calculates positions. The case for equal
+                // heights is already handled above with `override_lhs_size`.
+                map_shift_lhs = |lhs: &NodeHandle<_, _, _, _, _, M>, shift: Option<_>| {
+                    debug_assert!(shift.is_none());
+
+                    if lhs.height() + 1 == lhs_height {
+                        handled_shift.set(true);
+                        Some(BubbleLhs {
+                            pos: lhs_pos,
+                            old_size: old_lhs_size,
+                            new_size: new_lhs_size,
+                        })
+                    } else {
+                        None
+                    }
+                };
+
+                map_sizes = |node: &mut NodeHandle<_, _, _, _, _, M>,
+                             child_or_key,
+                             mut sizes: fix::OpUpdateStateSizes<_>| {
+                    if node.height() != lhs_height || handled_shift.get() {
+                        return sizes;
+                    }
+
+                    let old_lhs_end = lhs_pos.add_right(old_lhs_size);
+                    let new_lhs_end = lhs_pos.add_right(new_lhs_size);
+
+                    let pos = sizes.override_pos.unwrap_or_else(|| match child_or_key {
+                        // SAFETY: docs for `OpUpdateState` guarantee that `k_idx` is within bounds
+                        // for `node`.
+                        ChildOrKey::Key(k_idx) => unsafe { node.leaf().key_pos(k_idx) },
+                        ChildOrKey::Child(c_idx) => {
+                            let next_key_pos: I = node
+                                .leaf()
+                                .try_key_pos(c_idx)
+                                .unwrap_or_else(|| node.leaf().subtree_size());
+                            next_key_pos.sub_left(sizes.old_size)
+                        }
+                    });
+
+                    let diff = pos.sub_left(old_lhs_end);
+                    sizes.old_size = sizes.old_size.add_left(diff).add_left(old_lhs_size);
+                    sizes.new_size = sizes.new_size.add_left(diff).add_left(new_lhs_size);
+                    sizes.override_pos = Some(lhs_pos);
+
+                    // We're currently at key `lhs_k_idx`, so we want to manually shift all of the
+                    // keys from `lhs_k_idx + 1` to the last key before what's automatically
+                    // handled.
+                    //
+                    // However, because we know we just inserted to the right-hand side of `lhs`,
+                    // we know that we only actually need to shift a single key -- if at all. We
+                    // shift the key at `lhs_k_idx + 1` so long as `state.child_or_key` is
+                    // `ChildOrKey::Key((_, _))`.
+                    if let ChildOrKey::Key(_) = child_or_key {
+                        // SAFETY: the calls to `key_pos` and `set_single_key_pos` both require
+                        // only that `lhs_k_idx + 1` is a valid key index. Because (a) `node` is at
+                        // the same height as `lhs` and (b) any splits are not continued at this
+                        // height, we know that the index in `ChildOrKey::Key` must be equal to
+                        // `lhs_k_idx + 1`. The documentation for `PostInsertTraversalState`
+                        // guarantees that such a key index will be valid.
+                        unsafe {
+                            let pos = node.leaf().key_pos(lhs_k_idx + 1);
+                            let new_pos = pos.sub_left(old_lhs_end).add_left(new_lhs_end);
+                            node.set_single_key_pos(lhs_k_idx + 1, new_pos);
+                        }
+                    }
+
+                    sizes
+                };
+
+                (None, MapBubbledInsertState {
+                    post_op: MapOpUpdateState {
+                        cursor: Some(&mut map_cursor),
+                        sizes: Some(&mut map_sizes),
+                    },
+                    shift_lhs: Some(&mut map_shift_lhs),
+                })
+            }
         };
 
         // SAFETY: `do_insert_no_join` requires that `insert_idx <= next_leaf.leaf().len()`, which
@@ -1094,133 +1049,17 @@ where
         // It also requires that `insert_idx != 0` if `override_lhs_size.is_some()`, which is
         // guaranteed by our search procedure above; `insert_idx = lhs_k_idx + 1` if `next_leaf` is
         // at the same height, and is otherwise equal to zero.
-        let res = unsafe {
-            Self::do_insert_no_join::<C>(store, next_leaf, insert_idx, override_lhs_size, fst, snd)
-        };
-
-        // If `override_lhs_size` was provided, the change in `lhs`'s size was entirely handled by
-        // `do_insert_no_join`, so we don't need to do anything else here. Finish up the bubbled
-        // insert state if required
-        if override_lhs_size.is_some() {
-            let mut res = res;
-            loop {
-                match res {
-                    Ok(post_insert) => return post_insert,
-                    Err(bubble_state) => res = bubble_state.do_upward_step(store, None),
-                }
-            }
-        }
-
-        let mut handled_shift = false;
-
-        let post_insert_result = match res {
-            Ok(s) => s,
-            Err(mut bubble_state) => loop {
-                let mut maybe_shift_lhs = None;
-
-                // If the bubble state *will* change the node at the height of `lhs`, then we need
-                // to change the way that it internally calculates positions. The case for equal
-                // heights is already handled above with `override_lhs_size`.
-                if bubble_state.lhs.height() + 1 == lhs_height {
-                    handled_shift = true;
-
-                    maybe_shift_lhs = Some(BubbleLhs {
-                        pos: lhs_pos,
-                        old_size: old_lhs_size,
-                        new_size: new_lhs_size,
-                    });
-                }
-
-                // SAFETY: `do_upward_step` requires: if `maybe_shift_lhs` is `Some(_)`, then there
-                // must be a key to the left of the child `bubble_state.lhs`. This is guaranteed by
-                // our logic above, where `maybe_shift_lhs` is only set to `Some(_)` if `right_of`
-                // is at the height of `bubble_state.lhs`'s parent.
-                match bubble_state.do_upward_step(store, maybe_shift_lhs) {
-                    Ok(post_insert) if handled_shift => return post_insert,
-                    Ok(post_insert) => break post_insert,
-                    Err(b) => bubble_state = b,
-                }
-            },
-        };
-
-        // If we get here, we're handling a `PostInsertTraversalResult` until we get up to the
-        // height of the original left-hand side.
-
-        let mut post_insert_result = post_insert_result;
-
-        loop {
-            let mut state = match post_insert_result {
-                PostInsertTraversalResult::Continue(s) => s,
-                // FIXME: these shouldn't be possible, right?
-                r => return r,
-            };
-
-            let node = match &mut state.child_or_key {
-                ChildOrKey::Key((_, node)) => node,
-                ChildOrKey::Child((_, internal_node)) => internal_node.untyped_mut(),
-            };
-
-            if node.height() != lhs_height {
-                post_insert_result = state.do_upward_step();
-                continue;
-            }
-
-            // node.height() == lhs_height: account for the change in `lhs` size
-            //
-            // The easiest way for us to do this is to just change the values of `child_or_key` (to
-            // the left-hand key) and `old_size`/`new_size` (to incorporate the changes to `lhs`).
-            //
-            // Because we just inserted to the immediate right-hand side of `right_of`, we're
-            // expecting `state.child_or_key` to either represent the key or child immediately to
-            // the right (i.e. `ChildOrKey::{Key,Child}(lhs_k_idx + 1)`). Updating the values then
-            // sets it to the `lhs` key.
-
-            debug_assert!(
-                matches!(&state.child_or_key, ChildOrKey::Child((i, _)) | ChildOrKey::Key((i, _)) if *i == lhs_k_idx + 1)
-                    || (leaf_height == lhs_height
-                        && matches!(&state.child_or_key, ChildOrKey::Key((i, _)) if *i == lhs_k_idx + 2))
-            );
-
-            let old_lhs_end = lhs_pos.add_right(old_lhs_size);
-            let new_lhs_end = lhs_pos.add_right(new_lhs_size);
-
-            let state_pos = state.override_pos.unwrap_or_else(|| match &state.child_or_key {
-                // SAFETY: docs for `PostInsertTraversalState` guarantee that `k_idx` is within
-                // bounds for `node`.
-                ChildOrKey::Key((k_idx, node)) => unsafe { node.leaf().key_pos(*k_idx) },
-                ChildOrKey::Child((c_idx, node)) => {
-                    let next_key_pos = node
-                        .leaf()
-                        .try_key_pos(*c_idx)
-                        .unwrap_or_else(|| node.leaf().subtree_size());
-                    next_key_pos.sub_left(state.old_size)
-                }
-            });
-
-            let diff = state_pos.sub_left(old_lhs_end);
-            state.old_size = state.old_size.add_left(diff).add_left(old_lhs_size);
-            state.new_size = state.new_size.add_left(diff).add_left(new_lhs_size);
-            state.override_pos = Some(lhs_pos);
-
-            // We're currently at key `lhs_k_idx`, so we want to manually shift all of the keys
-            // from `lhs_k_idx + 1` to the last key before what's automatically handled.
-            //
-            // However, because we know we just inserted to the right-hand side of `lhs`, we know
-            // that we only actually need to shift a single key -- if at all. We shift the key at
-            // `lhs_k_idx + 1` so long as `state.child_or_key` is `ChildOrKey::Key((_, _))`.
-            if let ChildOrKey::Key((_, node)) = &mut state.child_or_key {
-                // SAFETY: the calls to `key_pos` and `set_single_key_pos` both require only that
-                // `lhs_k_idx + 1` is a valid key index. Because (a) `node` is at the same height
-                // as `lhs` and (b) any splits are not continued at this height, we know that the
-                // index in `ChildOrKey::Key` must be equal to `lhs_k_idx + 1`. The documentation
-                // for `PostInsertTraversalState` guarantees that such a key index will be valid.
-                unsafe {
-                    let pos = node.leaf().key_pos(lhs_k_idx + 1);
-                    let new_pos = pos.sub_left(old_lhs_end).add_left(new_lhs_end);
-                    node.set_single_key_pos(lhs_k_idx + 1, new_pos);
-                }
-            }
-            return PostInsertTraversalResult::Continue(state);
+        unsafe {
+            Self::do_insert_full_edge_no_join::<C>(
+                store,
+                next_leaf,
+                insert_idx,
+                override_lhs_size,
+                fst,
+                snd,
+                updates_callback,
+                mapper,
+            )
         }
     }
 
@@ -1236,24 +1075,135 @@ where
     // `do_upward_step` (alongisde the mid-level `finish`)  //
     //////////////////////////////////////////////////////////
 
-    /// Helper function for [`do_insert_no_join`]; refer to that function for context
+    /// (*Internal*) Traverses down the `RleTree` from the root, to find where to insert
+    ///
+    /// If this method returns a [`ChildOrKey::Key`], `idx` is contained within the returned key
+    /// *and not at either of its borders*. Otherwise, if it returns a [`ChildOrKey::Child`], which
+    /// points to the border between two keys at which the value shoulld be inserted.
+    ///
+    /// **Note:** `cursor_hints` is received as an `impl Iterator` instead of the `Cursor` directly
+    /// so that cursor types with the same [`PathIter`] associated type will use the same
+    /// monomorphized function.
+    ///
+    /// [`PathIter`]: Cursor::PathIter
+    fn find_insertion_point<'t>(
+        root: NodeHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>,
+        cursor_hints: impl Iterator<Item = PathComponent>,
+        idx: I,
+    ) -> InsertionPoint<'t, I, S, P, M> {
+        let mut cursor_iter = Some(cursor_hints);
+        let mut node = root;
+        let mut target = idx;
+
+        let mut adjacent_keys = AdjacentKeys { lhs: None, rhs: None };
+
+        loop {
+            let cursor_hint = cursor_iter.as_mut().and_then(|iter| iter.next());
+
+            let mut search_result = search_step(node.borrow(), cursor_hint, target);
+            // If the result was the start of a key, we actually want to insert in the child
+            // immediately before it.
+            if let ChildOrKey::Key((k_idx, k_pos)) = search_result {
+                if k_pos == target {
+                    // SAFETY: `k_idx` is guaranteed to be a valid key index, so it's therefore a valid
+                    // child index as well.
+                    let child_size = unsafe { node.try_child_size(k_idx).unwrap_or(I::ZERO) };
+                    let child_pos = k_pos.sub_right(child_size);
+                    search_result = ChildOrKey::Child((k_idx, child_pos));
+                }
+            }
+
+            let hint_was_good = matches!(
+                (search_result, cursor_hint),
+                (ChildOrKey::Child((c_idx, _)), Some(h)) if c_idx == h.child_idx,
+            );
+            if !hint_was_good {
+                cursor_iter = None;
+            }
+
+            match search_result {
+                // A successful result. We don't need the adjacent keys anymore because the insertion
+                // will split `key_idx`
+                ChildOrKey::Key((k_idx, k_pos)) => {
+                    // SAFETY: The call to `find_insertion_point` guarantees that return values of
+                    // `ChildOrKey::Key` contains an index within the bounds of the node's keys.
+                    let handle = unsafe { node.into_slice_handle(k_idx) };
+
+                    return ChildOrKey::Key(SplitKeyInsert {
+                        handle,
+                        pos_in_key: target.sub_left(k_pos),
+                    });
+                }
+                // An index between keys -- we don't yet know if it's an internal or leaf node.
+                ChildOrKey::Child((child_idx, child_pos)) => {
+                    // Later on, we'll distinguish the type of node, but either way we need to update
+                    // the adjacent keys:
+                    if S::MAY_JOIN {
+                        // The key to the left of child index `i` is at key index `i - 1`. We should
+                        // only override the left-hand adjacent key if this child isn't the first one
+                        // in its node:
+                        if let Some(ki) = child_idx.checked_sub(1) {
+                            // SAFETY: the return from `find_insertion_point` guarantees that the child
+                            // index is within bounds, relative to the number of keys (i.e. less than
+                            // key len + 1). So subtracting 1 guarantees a valid key index.
+                            adjacent_keys.lhs = Some(unsafe { node.split_slice_handle(ki) });
+                        }
+
+                        // `child_idx` is the rightmost child if it's *equal* to `node.len_keys()`.
+                        // Anything less means we should get the key to the right of it.
+                        if child_idx < node.leaf().len() {
+                            // SAFETY: same as above. The right-hand side key is *at* key index
+                            // `child_idx` because child indexing starts left of key indexing
+                            adjacent_keys.rhs = Some(unsafe { node.split_slice_handle(child_idx) });
+                        }
+                    }
+
+                    match node.into_typed() {
+                        // If it's a leaf node, we've found an insertion point between two keys
+                        Type::Leaf(leaf) => {
+                            return ChildOrKey::Child(EdgeInsert {
+                                node: leaf,
+                                adjacent_keys,
+                                // Two things here: (a) child indexes are offset to occur in the gaps
+                                // *before* the key of the same index (i.e. child0, then key0, then child1)
+                                // and (b) the guarantees of `find_insertion_point` mean that th
+                                new_k_idx: child_idx,
+                            });
+                        }
+                        // Otherwise, we should keep going:
+                        Type::Internal(internal) => {
+                            let pos_in_child = target.sub_left(child_pos);
+                            target = pos_in_child;
+                            // SAFETY: This function only requires that `child_idx` be in bounds. This
+                            // is condition is guaranteed by `find_insertion_point`.
+                            node = unsafe { internal.into_child(child_idx) };
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Helper function for [`do_insert_full_edge_no_join`]
     ///
     /// ## Safety
     ///
-    /// This function has all of the same safety requirements as [`do_insert_no_join`], and *also*
-    /// requires that `node.leaf().len()` is sufficiently close to `node.leaf().max_len()` such
-    /// that it *doesn't* support adding `fst` and `snd`, if `snd` is `Some`.
+    /// This function has all of the same safety requirements as [`do_insert_full_edge_no_join`],
+    /// and *also* requires that `node.leaf().len()` is sufficiently close to
+    /// `node.leaf().max_len()` such that it *doesn't* support adding `fst` and `snd`, if `snd` is
+    /// `Some`.
     ///
-    /// [`do_insert_no_join`]: Self::do_insert_no_join
-    unsafe fn do_insert_no_join_split<'t, C: Cursor>(
+    /// [`do_insert_full_edge_no_join`]: Self::do_insert_full_edge_no_join
+    unsafe fn do_insert_full_edge_no_join_split<'t, C: Cursor>(
         store: &mut P::SliceRefStore,
         mut node: NodeHandle<ty::Leaf, borrow::Mut<'t>, I, S, P, M>,
         mut new_key_idx: u8,
         mut override_lhs_size: Option<I>,
         fst: SliceSize<I, S>,
         snd: Option<SliceSize<I, S>>,
-    ) -> Result<PostInsertTraversalResult<'t, C, I, S, P, M>, BubbledInsertState<'t, C, I, S, P, M>>
-    {
+        updates_callback: &mut impl FnMut(TraverseUpdate<I, S, P, M>),
+    ) -> BubbledInsertState<'t, C, I, S, P, M> {
         // There's a few cases here to determine where we split the node, depending both on
         // `new_key_idx` and `node.leaf().len()`. We'll illustrate them all, pretending for now
         // that `M = 3`. Our node is initially:
@@ -1389,13 +1339,14 @@ where
                 // function (so those are guaranteed by the caller), and also requires `M == 1`,
                 // which we can see is true.
                 unsafe {
-                    return Self::do_insert_no_join_split_small_m(
+                    return Self::do_insert_full_edge_no_join_split_small_m(
                         store,
                         node,
                         new_key_idx,
                         override_lhs_size,
                         fst,
                         snd,
+                        updates_callback,
                     );
                 };
             }
@@ -1428,6 +1379,12 @@ where
         // which we guarantee by the logic above, because `max_len = 2 * M`
         let (midpoint_key, rhs) = unsafe { node.split(midpoint_idx, store) };
         let mut rhs = NodeBox::new(rhs);
+
+        // Handle initial updates, to correspond to the current state. We'll do more later, as
+        // we sort out individual cases.
+        for upd in TraverseUpdate::split(&node, midpoint_idx, &rhs.node) {
+            updates_callback(upd);
+        }
 
         let old_node_size = node.leaf().subtree_size();
         let rhs_start = rhs.as_ref().leaf().try_key_pos(0).unwrap_or(old_node_size);
@@ -1484,6 +1441,11 @@ where
                 // SAFETY: `push_key` requires only that there's space. This is guaranteed by
                 // having a value of `midpoint_idx` that removes *some* values from `node`.
                 unsafe { node.push_key(store, midpoint_key, new_lhs_subtree_size) };
+                updates_callback(TraverseUpdate::PutBack {
+                    ptr: node.ptr(),
+                    height: node.height(),
+                    idx: node.leaf().len() - 1,
+                });
 
                 // If we have a second slice that we're adding, it should go at the start of `rhs`,
                 // which is directly after the midpoint.
@@ -1505,7 +1467,7 @@ where
                     }
                 }
 
-                Err(BubbledInsertState {
+                BubbledInsertState {
                     lhs: node.erase_type(),
                     key: node::Key {
                         pos: rhs_start,
@@ -1515,9 +1477,10 @@ where
                     key_size: fst.size,
                     rhs: rhs.erase_type(),
                     old_size: old_node_size,
-                    insertion: None,
+                    shift_lhs: None,
+                    insertion_side: None,
                     partial_cursor: C::new_empty(),
-                })
+                }
             }
             Err(Side::Left) => {
                 let snd = match snd {
@@ -1541,23 +1504,23 @@ where
                 // SAFETY: our careful case-by-case logic above guarantees that there's always room
                 // to put the midpoint and first key into the left-hand node, which is all that
                 // `push_key` requires.
+                let mp_idx = node.leaf().len();
                 unsafe {
                     node.push_key(store, midpoint_key, lhs_key_end);
                     node.push_key(store, fst_key, fst_key_end);
                 }
 
-                // We always use `fst` as the handle, and we know it's at the end of `node`:
-                //
-                // SAFETY: `into_slice_handle` requires that the index is valid (which we know it
-                // is because we just put it there). `clone_slice_ref` requires that we not use it
-                // until the other borrows on the tree are gone, which the safety docs for
-                // `BubbledInsertState` guarantees.
-                let inserted_handle = unsafe {
-                    let idx = node.leaf().len() - 1;
-                    node.borrow().into_slice_handle(idx).clone_slice_ref()
-                };
+                // SAFETY: the `push_key`s above guarantee that `node.leaf().len()` is at least two
+                // greater than `mp_idx` (i.e. `mp_idx + 1 < node.leaf().len()`), which is requried
+                // by the calls to `into_slice_handle`.
+                unsafe {
+                    let midpoint_slice = node.borrow().into_slice_handle(mp_idx);
+                    let fst_key_slice = node.borrow().into_slice_handle(mp_idx + 1);
+                    updates_callback(TraverseUpdate::put_back(&midpoint_slice));
+                    updates_callback(TraverseUpdate::insert(&fst_key_slice));
+                }
 
-                Err(BubbledInsertState {
+                BubbledInsertState {
                     lhs: node.erase_type(),
                     key: node::Key {
                         pos: fst_key_end,
@@ -1567,12 +1530,10 @@ where
                     key_size: snd.size,
                     rhs: rhs.erase_type(),
                     old_size: old_node_size,
-                    insertion: Some(BubbledInsertion {
-                        side: Side::Left,
-                        handle: inserted_handle.erase_type(),
-                    }),
+                    shift_lhs: None,
+                    insertion_side: Some(Side::Left),
                     partial_cursor: C::new_empty(),
-                })
+                }
             }
             Ok(side) => {
                 let insert_into = match side {
@@ -1639,46 +1600,46 @@ where
                 }
 
                 // SAFETY: `into_slice_handle` requires `new_key_idx < insert_into.leaf().len()`,
-                // which is guaranteed by `insert_key`. `clone_slice_ref` requires that we not use
-                // it until the other borrows on the tree are gone, which the safety docs for
-                // `BubbledInsertState` guarantees.
-                let inserted_handle = unsafe {
-                    insert_into.borrow().into_slice_handle(new_key_idx).clone_slice_ref()
-                };
+                // which is guaranteed by `insert_key`.
+                let inserted_handle =
+                    unsafe { insert_into.borrow().into_slice_handle(new_key_idx) };
+                updates_callback(TraverseUpdate::insert(&inserted_handle));
 
-                Err(BubbledInsertState {
+                BubbledInsertState {
                     lhs: node.erase_type(),
                     key: midpoint_key,
                     key_size: midpoint_size,
                     rhs: rhs.erase_type(),
                     old_size: old_node_size,
-                    insertion: Some(BubbledInsertion {
-                        side,
-                        handle: inserted_handle.erase_type(),
-                    }),
+                    shift_lhs: None,
+                    insertion_side: Some(side),
                     partial_cursor: C::new_empty(),
-                })
+                }
             }
         }
     }
 
-    /// Helper function for [`do_insert_no_join_split`]; refer to that function for context
+    /// Helper function for [`do_insert_full_edge_no_join_split`]; refer to that function for
+    /// context
+    ///
+    /// Even though both `fst` and `snd` are provided, `updates_callback` will only be called with
+    /// a `TraverseUpdate::Insertion` for `fst`.
     ///
     /// ## Safety
     ///
-    /// This function has all of the same safety requirements as [`do_insert_no_join_split`] and
-    /// *also* requires that `M = 1`.
+    /// This function has all of the same safety requirements as
+    /// [`do_insert_full_edge_no_join_split`] and *also* requires that `M = 1`.
     ///
-    /// [`do_insert_no_join_split`]: Self::do_insert_no_join_split
-    unsafe fn do_insert_no_join_split_small_m<'t, C: Cursor>(
+    /// [`do_insert_full_edge_no_join_split`]: Self::do_insert_full_edge_no_join_split
+    unsafe fn do_insert_full_edge_no_join_split_small_m<'t, C: Cursor>(
         store: &mut P::SliceRefStore,
         mut node: NodeHandle<ty::Leaf, borrow::Mut<'t>, I, S, P, M>,
         new_key_idx: u8,
         override_lhs_size: Option<I>,
         fst: SliceSize<I, S>,
         snd: SliceSize<I, S>,
-    ) -> Result<PostInsertTraversalResult<'t, C, I, S, P, M>, BubbledInsertState<'t, C, I, S, P, M>>
-    {
+        updates_callback: &mut impl FnMut(TraverseUpdate<I, S, P, M>),
+    ) -> BubbledInsertState<'t, C, I, S, P, M> {
         // SAFETY: these are all guaranteed by the caller in some form. refer to the individual
         // comments for more information.
         unsafe {
@@ -1726,10 +1687,27 @@ where
             None => old_size,
         };
 
+        let updates;
+        let insertion_side;
+
+        // We either have [fst_key, snd_key, previous] or [previous, fst_key, snd_key]
+        //
+        // A note on updates: The only items that we care about updating are from `previous` and
+        // `fst_key` (`snd_key` doesn't count for insertions).
         #[rustfmt::skip]
         let ((lhs_key, lhs_size), (mid_key, mid_size), (rhs_key, rhs_size)) = if new_key_idx == 0 {
+            updates = Some([
+                TraverseUpdate::Move {
+                    old_ptr: node.ptr(), old_range: 0..1,
+                    new_ptr: rhs.node.ptr(), new_height: rhs.node.height(), new_range: 0..1,
+                },
+                TraverseUpdate::Insertion { ptr: node.ptr(), height: node.height(), idx: 0 },
+            ]);
+            insertion_side = Some(Side::Left);
             ((fst_key, fst.size), (snd_key, snd.size), (midpoint_key, midpoint_size))
         } else /* new_key_idx == 1 */ {
+            updates = None;
+            insertion_side = None;
             ((midpoint_key, midpoint_size), (fst_key, fst.size), (snd_key, snd.size))
         };
 
@@ -1741,39 +1719,36 @@ where
             rhs.as_mut().push_key(store, rhs_key, rhs_size);
         }
 
-        // iF `new_key_idx` is 1, then `fst` ends up as the midpoint, so we can't produce a handle
-        // to the insertion yet. Otherwise (`new_key_idx == 0`), it ends up as the left-hand node's
-        // only value, so we get it from there.
-        #[rustfmt::skip]
-        let insertion = if new_key_idx == 1 {
-            None
-        } else /* new_key_idx == 0 */ {
-            // SAFETY: `into_slice_handle` requires that the key index is valid, which we know is
-            // true because we just pushed the value into `node`. `clone_slice_ref` requires that
-            // we don't use the value until after the other borrows on the tree are dropped, which
-            // is guaranteed by the safety docs for `BubbledInsertState`.
-            let handle = unsafe { node.borrow().into_slice_handle(0).clone_slice_ref() };
+        // Note: we wait to perform the updates until *after* the values have been put into their
+        // places. Otherwise, we'd be handing out pointers to things that don't yet exist.
+        if let Some([fst_upd, snd_upd]) = updates {
+            updates_callback(fst_upd);
+            updates_callback(snd_upd);
+        }
 
-            Some(BubbledInsertion { side: Side::Left, handle: handle.erase_type() })
-        };
-
-        Err(BubbledInsertState {
+        BubbledInsertState {
             lhs: node.erase_type(),
             key: mid_key,
             key_size: mid_size,
             rhs: rhs.erase_type(),
             old_size,
-            insertion,
+            shift_lhs: None,
+            insertion_side,
             partial_cursor: C::new_empty(),
-        })
+        }
     }
 }
 
+/// A one-off struct used only in the `shift_lhs` field of [`BubbledInsertState`]
+///
+/// For further context of why this type is used, refer to the documentation on
+/// [`BubbledInsertState`] itself.
 #[derive(Debug, Copy, Clone)]
-struct BubbleLhs<I> {
-    pos: I,
-    old_size: I,
-    new_size: I,
+pub(super) struct BubbleLhs<I> {
+    /// `pos` gives the "true" position of the left-hand node, which may disagree
+    pub(super) pos: I,
+    pub(super) old_size: I,
+    pub(super) new_size: I,
 }
 
 impl<'t, C, I, S, P, const M: usize> BubbledInsertState<'t, C, I, S, P, M>
@@ -1783,11 +1758,34 @@ where
     S: Slice<I>,
     P: RleTreeConfig<I, S, M>,
 {
+    fn finish<'m>(
+        mut self,
+        store: &mut P::SliceRefStore,
+        mut map: <BubbledInsertState<'t, C, I, S, P, M> as MapState>::Map<'m>,
+        updates_callback: &mut impl FnMut(TraverseUpdate<I, S, P, M>),
+        early_exit: Option<&mut dyn FnMut(&OpUpdateState<'t, C, I, S, P, M>) -> ControlFlow<()>>,
+    ) -> PostInsertResult<'t, C, I, S, P, M>
+    where
+        Self: 'm,
+    {
+        loop {
+            self = self.map(&mut map);
+            match self.do_upward_step(store, updates_callback) {
+                BubbleStepResult::KeepGoing(new_state) => self = new_state,
+                BubbleStepResult::Root(result) => return result,
+                BubbleStepResult::Done(post_op_state) => {
+                    let cursor = post_op_state.finish(map.post_op, early_exit);
+                    return PostInsertResult::Done(cursor);
+                }
+            }
+        }
+    }
+
     fn do_upward_step(
         mut self,
-        store: &mut <P as RleTreeConfig<I, S, M>>::SliceRefStore,
-        mut shift_lhs: Option<BubbleLhs<I>>,
-    ) -> Result<PostInsertTraversalResult<'t, C, I, S, P, M>, Self> {
+        store: &mut P::SliceRefStore,
+        updates_callback: &mut impl FnMut(TraverseUpdate<I, S, P, M>),
+    ) -> BubbleStepResult<'t, C, I, S, P, M> {
         let lhs_size = self.lhs.leaf().subtree_size();
         let new_total_size = lhs_size
             .add_right(self.key_size)
@@ -1799,23 +1797,21 @@ where
             // Base case: no parent, need to create a new `Internal` root. That has to be done from
             // the main function, `insert_internal`, so we need to return a result indicating that.
             Err(lhs) => {
-                assert!(shift_lhs.is_none(), "internal error: this is a bug");
+                assert!(self.shift_lhs.is_none(), "internal error: this is a bug");
 
-                let insertion = self.insertion.map(|insertion| {
+                if let Some(side) = self.insertion_side {
                     self.partial_cursor.prepend_to_path(PathComponent {
                         // `Side` is explicitly tagged so that Side::Left = 0 and Side::Right = 1
-                        child_idx: insertion.side as u8,
+                        child_idx: side as u8,
                     });
-                    insertion.handle
-                });
+                }
 
-                return Ok(PostInsertTraversalResult::NewRoot {
+                return BubbleStepResult::Root(PostInsertResult::NewRoot {
                     cursor: self.partial_cursor,
                     lhs,
                     key: self.key,
                     key_size: self.key_size,
                     rhs: self.rhs,
-                    insertion,
                 });
             }
         };
@@ -1825,7 +1821,7 @@ where
         // Do the minimal amount of work here, and let `PostInsertTraversalState::do_upward_step`
         // handle the rest.
         if parent.leaf().len() < parent.leaf().max_len() {
-            let (override_pos, old_size, new_size, lhs_child_pos) = match shift_lhs {
+            let (override_pos, old_size, new_size, lhs_child_pos) = match self.shift_lhs {
                 Some(k) => (
                     k.pos,
                     self.old_size.add_left(k.old_size),
@@ -1863,37 +1859,30 @@ where
                 parent.set_single_key_pos(lhs_child_idx, midpoint_pos);
             };
 
-            // Update the cursor -- and the insertion handle if necessary.
-            //
-            // We have to do this because we're lying to `PostInsertTraversalState` about where the
-            // insertion is in order to get it to use the correct key position for shifting and it
-            // won't update the cursor if we don't say it's in a `Child`.
-            let insertion = match self.insertion {
-                Some(insertion) => {
-                    self.partial_cursor.prepend_to_path(PathComponent {
-                        child_idx: lhs_child_idx + insertion.side as u8,
-                    });
-
-                    insertion.handle
-                }
-                None => {
-                    // keys and their left-hand child always have the same index.
-                    let key_idx = lhs_child_idx;
-
-                    // SAFETY: `into_slice_handle` requires that `key_idx < parent.leaf().len()`,
-                    // which we've already guaranteed by insertion. `clone_slice_ref` requires that
-                    // we not use the handle until the original borrow on the tree is gone, which
-                    // is mirrored in the docs for `PostInsertTraversalState`.
-                    let handle =
-                        unsafe { parent.borrow().into_slice_handle(key_idx).clone_slice_ref() };
-                    handle.erase_type()
-                }
+            // SAFETY: `into_slice_handle` requires that `key_idx < parent.leaf().len()`, which
+            // we've already guaranteed by insertion.
+            let handle = unsafe { parent.borrow().into_slice_handle(lhs_child_idx).erase_type() };
+            let make_update = match self.insertion_side {
+                // Already inserted our value; we're putting something else back
+                Some(_) => TraverseUpdate::put_back,
+                // This is an initial insertion of the target value
+                None => TraverseUpdate::insert,
             };
+            updates_callback(make_update(&handle));
 
-            return Ok(PostInsertTraversalResult::Continue(PostInsertTraversalState {
-                inserted_slice: insertion,
+            // Update the cursor
+            //
+            // We have to do this because we're lying to `OpUpdateState` about where the insertion
+            // is in order to get it to use the correct key position for shifting and it won't
+            // update the cursor if we don't say it's in a `Child`.
+            if let Some(side) = self.insertion_side {
+                self.partial_cursor
+                    .prepend_to_path(PathComponent { child_idx: lhs_child_idx + side as u8 });
+            }
+
+            return BubbleStepResult::Done(OpUpdateState {
                 // We need to use the midpoint key here so that
-                // `PostInsertTraversalState::do_upward_step` updates only the keys after the
+                // `OpUpdateState::do_upward_step` updates only the keys after the
                 // lhs-key-rhs grouping. The midpoint key has the same index as the left-hand
                 // child, so the shifting will start immediately after rhs.
                 child_or_key: ChildOrKey::Key((lhs_child_idx, parent.erase_type())),
@@ -1903,7 +1892,7 @@ where
                 old_size,
                 new_size,
                 partial_cursor: self.partial_cursor,
-            }));
+            });
         }
         // Couldn't just insert: need to split
 
@@ -1989,7 +1978,7 @@ where
 
             // Handle a special case with `shift_lhs`. All other cases (for `new_key_idx != M`)
             // will have the left-hand key on the same side of the split as the insertion.
-            if let (Some(shift), true) = (shift_lhs, new_key_idx == M as u8 + 1) {
+            if let (Some(shift), true) = (self.shift_lhs, new_key_idx == M as u8 + 1) {
                 // If we have change the side of the left-hand key, AND that key is the current
                 // midpoint (because `new_key_idx` is at the start of `rhs`), then the change for
                 // `shift_lhs` can be made *just* by changing the size of the midpoint key.
@@ -2004,7 +1993,7 @@ where
                 midpoint_size = shift.new_size;
 
                 // remove `shift_lhs` to mark it as being resolved
-                shift_lhs = None;
+                self.shift_lhs = None;
             }
 
             let (side, insert_into) = if new_key_idx < M as u8 {
@@ -2014,14 +2003,14 @@ where
                 new_key_idx -= M as u8 + 1;
 
                 // Appropriately adjsut `shift_lhs` to be relative to the right-hand node now
-                if let Some(s) = shift_lhs.as_mut() {
+                if let Some(s) = self.shift_lhs.as_mut() {
                     s.pos = s.pos.sub_left(rhs_start);
                 }
 
                 (Side::Right, rhs.as_mut())
             };
 
-            let (lhs_child_pos, shift_pos, mut old_size, mut new_size) = match shift_lhs {
+            let (lhs_child_pos, shift_pos, mut old_size, mut new_size) = match self.shift_lhs {
                 None => {
                     // Like our careful maneuvering above to get `rhs_start`, we have to similarly
                     // ignore the *current* influence of `self.lhs` when we get its position,
@@ -2063,15 +2052,11 @@ where
             // At this point, we know that our value has definitely been inserted -- it was either
             // a key or child from `self.lhs/`self.rhs`, or `self.key`. We didn't take anything out
             // of `self.{lhs,rhs}`, so we don't need to worry about the pointer becoming invalid.
-            let insertion = match self.insertion {
-                Some(insertion) => {
-                    self.partial_cursor.prepend_to_path(PathComponent {
-                        child_idx: new_key_idx + insertion.side as u8,
-                    });
-
-                    BubbledInsertion { side, handle: insertion.handle }
+            match self.insertion_side {
+                Some(s) => {
+                    self.partial_cursor
+                        .prepend_to_path(PathComponent { child_idx: new_key_idx + s as u8 });
                 }
-
                 // the insertion was in `self.key`. There isn't much we need to do because the
                 // cursor can't be written to yet.
                 None => {
@@ -2080,24 +2065,24 @@ where
                     // `insert_key_and_child`. `clone_slice_ref` requires that we not use it until
                     // the other borrows on the tree are gone, which the safety docs for
                     // `BubbledInsertState` guarantees.
-                    let inserted_handle = unsafe {
-                        insert_into.borrow().into_slice_handle(new_key_idx).clone_slice_ref()
-                    };
+                    let inserted_handle =
+                        unsafe { insert_into.borrow().into_slice_handle(new_key_idx) };
+
+                    updates_callback(TraverseUpdate::insert(&inserted_handle));
 
                     // Don't have to update `self.partial_cursor` because the value got inserted as
                     // a key, not a child.
-
-                    BubbledInsertion { side, handle: inserted_handle.erase_type() }
                 }
-            };
+            }
 
-            Err(BubbledInsertState {
+            BubbleStepResult::KeepGoing(BubbledInsertState {
                 lhs: parent.erase_type(),
                 key: midpoint_key,
                 key_size: midpoint_size,
                 rhs: rhs.erase_type(),
                 old_size: old_parent_size,
-                insertion: Some(insertion),
+                shift_lhs: None,
+                insertion_side: Some(side),
                 partial_cursor: self.partial_cursor,
             })
         } else {
@@ -2124,7 +2109,7 @@ where
             // will happen to `C` -- the current midpoint and eventual last key in the left-hand
             // node. So we can fully account for `shift_lhs` by correcting the size of the midpoint
             // key.
-            if let Some(lhs) = shift_lhs {
+            if let Some(lhs) = self.shift_lhs {
                 midpoint_size = lhs.new_size;
             }
 
@@ -2178,16 +2163,16 @@ where
                 shift_keys_auto(rhs.as_mut(), opts)
             }
 
-            // If `self.insertion` was `None` (i.e. the insertion was in `self.key`), then it's
-            // still there. We only need to do anything if `self.insertion` is not `None`
-            if let Some(insertion) = self.insertion.as_ref() {
+            // If `self.insertion_side` was `None` (i.e. the insertion was in `self.key`), then
+            // it's still there. We only need to do anything if `self.insertion_side` is not `None`
+            if let Some(side) = self.insertion_side {
                 // In this case, the `side` associated with the insertion remained the same;
                 // `self.lhs` ended up at the end of its node, and `self.rhs` ended up at the
                 // beginning of the next.
                 //
                 // All we need to do here is record the child index for the cursor.
 
-                let child_idx = match insertion.side {
+                let child_idx = match side {
                     Side::Left => 0,
                     // There are `M` keys in `parent`, so the index of the last child is also `M`
                     Side::Right => M as u8,
@@ -2196,95 +2181,75 @@ where
                 self.partial_cursor.prepend_to_path(PathComponent { child_idx });
             }
 
-            Err(BubbledInsertState {
+            BubbleStepResult::KeepGoing(BubbledInsertState {
                 lhs: parent.erase_type(),
                 key: self.key,
                 key_size: self.key_size,
                 rhs: rhs.erase_type(),
                 old_size: old_parent_size,
-                insertion: self.insertion,
+                shift_lhs: None,
+                insertion_side: self.insertion_side,
                 partial_cursor: self.partial_cursor,
             })
         }
     }
 }
 
-impl<'t, C, I, S, P, const M: usize> PostInsertTraversalState<'t, C, I, S, P, M>
+/// The result of calling [`BubbledInsertState::do_upward_step`]
+enum BubbleStepResult<'t, C, I, S, P: RleTreeConfig<I, S, M>, const M: usize> {
+    /// The [`BubbledInsertState`] has reached the root
+    Root(PostInsertResult<'t, C, I, S, P, M>),
+    /// Changes in tree structure from the [`BubbledInsertState`] have been resolved, and there are
+    /// still more nodes to traverse
+    Done(OpUpdateState<'t, C, I, S, P, M>),
+    KeepGoing(BubbledInsertState<'t, C, I, S, P, M>),
+}
+
+/// Struct containing `dyn` functions that map [`BubbledInsertState`]s (See: [`MapState`])
+///
+/// This type also includes the mapping functions for the [`OpUpdateState`] that will continue the
+/// traversal up the tree once we've stopped "bubbling" the insertion.
+pub(super) struct MapBubbledInsertState<'f, 't, C: 'f, I, S, P, const M: usize>
 where
-    C: Cursor,
-    I: Index,
-    S: Slice<I>,
     P: RleTreeConfig<I, S, M>,
 {
-    fn do_upward_step(mut self) -> PostInsertTraversalResult<'t, C, I, S, P, M> {
-        // The first part of the traversal step starts with repositioning all of the keys after
-        // `self.child_or_key`.
+    pub(super) post_op: <OpUpdateState<'t, C, I, S, P, M> as MapState>::Map<'f>,
+    pub(super) shift_lhs: Option<
+        &'f mut dyn FnMut(
+            &NodeHandle<ty::Unknown, borrow::Mut<'t>, I, S, P, M>,
+            Option<BubbleLhs<I>>,
+        ) -> Option<BubbleLhs<I>>,
+    >,
+}
 
-        let (mut node, first_key_after, maybe_child_idx, pos) = match self.child_or_key {
-            ChildOrKey::Key((k_idx, node)) => {
-                let pos = self
-                    .override_pos
-                    // SAFETY: The documentation for `PostInsertTraversalState` guarantees that
-                    // `k_idx` is within bounds.
-                    .unwrap_or_else(|| unsafe { node.leaf().key_pos(k_idx) });
+impl<'t, C, I, S, P, const M: usize> MapState for BubbledInsertState<'t, C, I, S, P, M>
+where
+    P: RleTreeConfig<I, S, M>,
+{
+    type Map<'f> = MapBubbledInsertState<'f, 't, C, I, S, P, M> where Self: 'f;
 
-                (node, k_idx + 1, None, pos)
-            }
-            ChildOrKey::Child((c_idx, node)) => {
-                let pos = self.override_pos.unwrap_or_else(|| {
-                    let next_key_pos = node
-                        .leaf()
-                        .try_key_pos(c_idx)
-                        .unwrap_or_else(|| node.leaf().subtree_size());
-                    next_key_pos.sub_left(self.old_size)
-                });
+    fn identity<'f>() -> Self::Map<'f>
+    where
+        Self: 'f,
+    {
+        MapBubbledInsertState {
+            post_op: <OpUpdateState<'t, C, I, S, P, M> as MapState>::identity(),
+            shift_lhs: None,
+        }
+    }
 
-                (node.erase_type(), c_idx, Some(c_idx), pos)
-            }
-        };
-
-        let old_size = node.leaf().subtree_size();
-
-        // SAFETY: `shift_keys` only requires that `from` is less than or equal to
-        // `node.leaf().len()`. This can be verified by looking at the code above; `from` is either
-        // set to `k_idx + 1` or to `c_idx`, both of which exactly meet the required bound.
-        unsafe {
-            shift_keys_increase(&mut node, ShiftKeys {
-                from: first_key_after,
-                pos,
-                old_size: self.old_size,
-                new_size: self.new_size,
-            });
+    fn map<'f>(mut self, f: &mut Self::Map<'f>) -> Self
+    where
+        Self: 'f,
+    {
+        if let Some(map_cursor) = f.post_op.cursor.as_mut() {
+            self.partial_cursor = map_cursor(&self.lhs, self.partial_cursor);
         }
 
-        let new_size = node.leaf().subtree_size();
-
-        // Update the cursor
-        //
-        // Technically speaking, this relies on this node having `child_or_key =
-        // ChildOrKey::Child(_)` as long as the cursor is non-empty, but that should always be
-        // true.
-        if let Some(child_idx) = maybe_child_idx {
-            self.partial_cursor.prepend_to_path(PathComponent { child_idx });
+        if let Some(map_shift) = f.shift_lhs.as_mut() {
+            self.shift_lhs = map_shift(&self.lhs, self.shift_lhs);
         }
 
-        // Update `self` to the parent, if there is one. Otherwise, this is the root node so we
-        // should return `Err` with the cursor and reference to the insertion.
-        match node.into_parent().ok() {
-            None => PostInsertTraversalResult::Root {
-                cursor: self.partial_cursor,
-                insertion: self.inserted_slice,
-            },
-            Some((parent_handle, c_idx)) => {
-                PostInsertTraversalResult::Continue(PostInsertTraversalState {
-                    inserted_slice: self.inserted_slice,
-                    child_or_key: ChildOrKey::Child((c_idx, parent_handle)),
-                    override_pos: None,
-                    old_size,
-                    new_size,
-                    partial_cursor: self.partial_cursor,
-                })
-            }
-        }
+        self
     }
 }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -2843,12 +2843,12 @@ where
 }
 
 // Any params
+//  * borrow
 //  * erase_type
 //  * key_pos
 //  * slice_size
 //  * is_hole
 //  * clone_slice_ref
-//  * clone_immut
 //  * take_refid
 //  * replace_refid
 //  * redirect_to
@@ -3134,5 +3134,24 @@ where
         }
 
         pos..pos.add_right(size)
+    }
+
+    /// Creates a [`SliceHandle`] from the raw parts
+    ///
+    /// ## Safety
+    ///
+    /// THIS FUNCTION IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPR-
+    ///
+    /// Anyways. Basically you have to pinkie promise that all of the arguments are valid, that the
+    /// [`SliceHandle`] will not be accessed (a) after changes to its node or (b) before all other
+    /// changes within the [`RleTree`] have finished.
+    ///
+    /// [`RleTree`]: super::RleTree
+    pub(super) unsafe fn from_raw_parts(ptr: NodePtr<I, S, P, M>, height: u8, idx: u8) -> Self {
+        let node = NodeHandle { ptr, height, borrow: PhantomData };
+        // SAFETY: Guaranteed by the caller.
+        unsafe { weak_assert!(idx < node.leaf().len()) };
+
+        SliceHandle { node, idx }
     }
 }

--- a/src/tree/tests/slice_ref.rs
+++ b/src/tree/tests/slice_ref.rs
@@ -20,3 +20,21 @@ fn auto_fuzz_2_insert_panics() {
         std::panic::catch_unwind(move || { tree_0.insert_ref(75, Constant('F'), 245) }).is_err()
     );
 }
+
+#[test]
+#[allow(unused_variables)]
+fn auto_fuzz_3_insert_deferred_after_split() {
+    let mut tree_0: SliceRefFuzzTree = RleTree::new_empty();
+    let ref_0 = tree_0.insert_ref(0, Constant('A'), 69);
+    assert_eq!(ref_0.range(), 0..69);
+    assert_eq!(ref_0.range(), 0..69);
+    let ref_1 = tree_0.insert_ref(12, Constant('M'), 12);
+    let ref_2 = tree_0.insert_ref(49, Constant('M'), 12);
+    let ref_3 = tree_0.insert_ref(12, Constant('L'), 51);
+    assert_eq!(ref_3.range(), 12..63);
+    assert_eq!(ref_0.range(), 0..12);
+    let ref_4 = tree_0.insert_ref(12, Constant('V'), 12);
+    let ref_5 = tree_0.insert_ref(51, Constant('M'), 12);
+    let ref_6 = tree_0.insert_ref(47, Constant('M'), 12);
+    assert!(std::panic::catch_unwind(move || { tree_0.insert_ref(0, Constant('A'), 0) }).is_err());
+}


### PR DESCRIPTION
There's a number of benefits for this - the primary one being that it'll be easier to implement deletion this way, because callbacks are composable. This comes with a general shift from our current "step functions where the caller does state mapping" to "caller provides mapping functions and the operations run to completion.